### PR TITLE
Update for ark crates 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 
 [dependencies]
-ark-bls12-381 = { version = "^0.3.0" }
-ark-ec = { version = "^0.3.0", default-features = false }
-ark-ff = { version = "^0.3.0", default-features = false }
-ark-std = { version = "^0.3.0", default-features = false }
+ark-bls12-381 = { version = "^0.4.0" }
+ark-ec = { version = "^0.4.0", default-features = false }
+ark-ff = { version = "^0.4.0", default-features = false }
+ark-std = { version = "^0.4.0", default-features = false }
 rayon = { version = "^1.5.1" }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 
 [dependencies]
-ark-bls12-381 = { version = "^0.4.0" }
 ark-ec = { version = "^0.4.0", default-features = false }
 ark-ff = { version = "^0.4.0", default-features = false }
 ark-std = { version = "^0.4.0", default-features = false }
 rayon = { version = "^1.5.1" }
 
 [dev-dependencies]
+ark-bls12-381 = { version = "^0.4.0" }
 criterion = { version = "0.3", features = [ "html_reports" ] } # benchmarks
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "groth-sahai"
 version = "0.1.0"
 authors = ["Jacob White <white570@purdue.edu>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "An implementation of the Groth-Sahai zero-knowledge proof system in Rust"
 repository = "https://github.com/jdwhite88/groth-sahai-rs"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -6,7 +6,10 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use std::time::Duration;
 
 use ark_bls12_381::Bls12_381 as F;
-use ark_ec::{pairing::Pairing, AffineRepr, CurveGroup};
+use ark_ec::{
+    pairing::{Pairing, PairingOutput},
+    AffineRepr, CurveGroup,
+};
 use ark_ff::{One, UniformRand, Zero};
 use ark_std::ops::Mul;
 use ark_std::str::FromStr;
@@ -18,7 +21,7 @@ type G1Projective = <F as Pairing>::G1;
 type G1Affine = <F as Pairing>::G1Affine;
 //type G2Projective = <F as PairingEngine>::G2Projective;
 type G2Affine = <F as Pairing>::G2Affine;
-type Fqk = <F as Pairing>::TargetField;
+type GT = PairingOutput<F>;
 type Fr = <F as Pairing>::ScalarField;
 
 // Uses an affine group generator to produce an affine group element represented by the numeric
@@ -427,7 +430,7 @@ fn bench_small_PPE_proof(c: &mut Criterion) {
         ],
         gamma: vec![vec![Fr::one()], vec![Fr::zero()]],
         // NOTE: dummy variable for this bench
-        target: Fqk::rand(&mut rng),
+        target: GT::rand(&mut rng),
     };
 
     c.bench_function("prove PPE equation with 2 G1 vars, 1 G2 var", |bench| {
@@ -473,7 +476,7 @@ fn bench_large_PPE_proof(c: &mut Criterion) {
         b_consts,
         gamma,
         // NOTE: dummy variable for this bench
-        target: Fqk::rand(&mut rng),
+        target: GT::rand(&mut rng),
     };
 
     c.bench_function(
@@ -505,7 +508,7 @@ fn bench_small_PPE_verify(c: &mut Criterion) {
         ],
         gamma: vec![vec![Fr::one()], vec![Fr::zero()]],
         // NOTE: dummy variable for this bench
-        target: Fqk::rand(&mut rng),
+        target: GT::rand(&mut rng),
     };
 
     let proof: CProof<F> = equ.commit_and_prove(&xvars, &yvars, &crs, &mut rng);
@@ -551,7 +554,7 @@ fn bench_large_PPE_verify(c: &mut Criterion) {
         b_consts,
         gamma,
         // NOTE: dummy variable for this bench
-        target: Fqk::rand(&mut rng),
+        target: GT::rand(&mut rng),
     };
 
     let proof: CProof<F> = equ.commit_and_prove(&xvars, &yvars, &crs, &mut rng);

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -15,7 +15,15 @@ use ark_std::ops::Mul;
 use ark_std::str::FromStr;
 use ark_std::test_rng;
 
-use groth_sahai::{prover::*, statement::*, verifier::*, AbstractCrs, Com1, Mat, Matrix, B1, CRS};
+use groth_sahai::{
+    prover::{
+        batch_commit_G1, batch_commit_G2, batch_commit_scalar_to_B1, batch_commit_scalar_to_B2,
+        CProof, Commit1, Commit2, Provable,
+    },
+    statement::PPE,
+    verifier::Verifiable,
+    AbstractCrs, Com1, Mat, Matrix, B1, CRS,
+};
 
 type G1Projective = <F as Pairing>::G1;
 type G1Affine = <F as Pairing>::G1Affine;

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,4 +1,3 @@
-
 #![allow(non_snake_case)]
 #![allow(dead_code)]
 
@@ -8,94 +7,79 @@ use criterion::{criterion_group, criterion_main, Criterion};
 
 use std::time::Duration;
 
-use ark_bls12_381::{Bls12_381 as F};
-use ark_ff::{UniformRand, field_new, One, Zero};
-use ark_ec::{AffineCurve, ProjectiveCurve, PairingEngine};
-use ark_std::{
-    test_rng
-};
+use ark_bls12_381::Bls12_381 as F;
+use ark_ec::{pairing::Pairing, AffineRepr, CurveGroup};
+use ark_ff::{One, UniformRand, Zero};
+use ark_std::ops::Mul;
+use ark_std::str::FromStr;
+use ark_std::test_rng;
 
-use groth_sahai::{
-    prover::*,
-    statement::*,
-    verifier::*,
-    B1, Com1, Mat, Matrix,
-    CRS, AbstractCrs
-};
+use groth_sahai::{prover::*, statement::*, verifier::*, AbstractCrs, Com1, Mat, Matrix, B1, CRS};
 
-type G1Projective = <F as PairingEngine>::G1Projective;
-type G1Affine = <F as PairingEngine>::G1Affine;
+type G1Projective = <F as Pairing>::G1;
+type G1Affine = <F as Pairing>::G1Affine;
 //type G2Projective = <F as PairingEngine>::G2Projective;
-type G2Affine = <F as PairingEngine>::G2Affine;
-type Fqk = <F as PairingEngine>::Fqk;
-type Fr = <F as PairingEngine>::Fr;
+type G2Affine = <F as Pairing>::G2Affine;
+type Fqk = <F as Pairing>::TargetField;
+type Fr = <F as Pairing>::ScalarField;
 
 // Uses an affine group generator to produce an affine group element represented by the numeric
 // string.
 macro_rules! affine_group_new {
     ($gen:expr, $strnum:tt) => {
-        $gen.mul(field_new!(Fr, $strnum)).into_affine()
-    }
+        $gen.mul(Fr::from_str($strnum).unwrap()).into_affine()
+    };
 }
 
 macro_rules! affine_group_rand {
     ($gen:expr, $rng:ident) => {
         $gen.mul(Fr::rand(&mut $rng)).into_affine()
-    }
+    };
 }
 
 pub fn bench_small_field_matrix_mul(c: &mut Criterion) {
-
     std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
     let mut rng = test_rng();
 
     // 2 x 2 matrix
     let lhs: Matrix<Fr> = vec![
-        vec![ Fr::rand(&mut rng), Fr::rand(&mut rng) ],
-        vec![ Fr::rand(&mut rng), Fr::rand(&mut rng) ]
+        vec![Fr::rand(&mut rng), Fr::rand(&mut rng)],
+        vec![Fr::rand(&mut rng), Fr::rand(&mut rng)],
     ];
     // 2 x 1 matrix
-    let rhs: Matrix<Fr> = vec![
-        vec![ Fr::rand(&mut rng) ],
-        vec![ Fr::rand(&mut rng) ]
-    ];
+    let rhs: Matrix<Fr> = vec![vec![Fr::rand(&mut rng)], vec![Fr::rand(&mut rng)]];
     c.bench_function(
         &format!("sequential (2 x 2) * (2 x 1) field matrix mult"),
         |bench| {
             bench.iter(|| {
                 let _ = lhs.right_mul(&rhs, false);
             });
-        }
+        },
     );
 }
 
 pub fn bench_small_field_matrix_mul_par(c: &mut Criterion) {
-
     std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
     let mut rng = test_rng();
 
     // 2 x 2 matrix
     let lhs: Matrix<Fr> = vec![
-        vec![ Fr::rand(&mut rng), Fr::rand(&mut rng) ],
-        vec![ Fr::rand(&mut rng), Fr::rand(&mut rng) ]
+        vec![Fr::rand(&mut rng), Fr::rand(&mut rng)],
+        vec![Fr::rand(&mut rng), Fr::rand(&mut rng)],
     ];
     // 2 x 1 matrix
-    let rhs: Matrix<Fr> = vec![
-        vec![ Fr::rand(&mut rng) ],
-        vec![ Fr::rand(&mut rng) ]
-    ];
+    let rhs: Matrix<Fr> = vec![vec![Fr::rand(&mut rng)], vec![Fr::rand(&mut rng)]];
     c.bench_function(
         &format!("concurrent (2 x 2) * (2 x 1) field matrix mult"),
         |bench| {
             bench.iter(|| {
                 let _ = lhs.right_mul(&rhs, true);
             });
-        }
+        },
     );
 }
 
 pub fn bench_large_field_matrix_mul(c: &mut Criterion) {
-
     std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
     let mut rng = test_rng();
 
@@ -103,7 +87,7 @@ pub fn bench_large_field_matrix_mul(c: &mut Criterion) {
     let m = 334;
     let mut lhs: Matrix<Fr> = Vec::with_capacity(m);
     for _ in 0..m {
-        lhs.push(vec![ Fr::rand(&mut rng), Fr::rand(&mut rng) ]);
+        lhs.push(vec![Fr::rand(&mut rng), Fr::rand(&mut rng)]);
     }
     // 2 x 334 matrix
     let n = 334;
@@ -111,7 +95,7 @@ pub fn bench_large_field_matrix_mul(c: &mut Criterion) {
     for _ in 0..2 {
         let mut tmp: Vec<Fr> = Vec::with_capacity(n);
         for _ in 0..n {
-            tmp.push( Fr::rand(&mut rng) );
+            tmp.push(Fr::rand(&mut rng));
         }
         rhs.push(tmp);
     }
@@ -121,12 +105,11 @@ pub fn bench_large_field_matrix_mul(c: &mut Criterion) {
             bench.iter(|| {
                 let _ = lhs.right_mul(&rhs, false);
             });
-        }
+        },
     );
 }
 
 pub fn bench_large_field_matrix_mul_par(c: &mut Criterion) {
-
     std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
     let mut rng = test_rng();
 
@@ -134,7 +117,7 @@ pub fn bench_large_field_matrix_mul_par(c: &mut Criterion) {
     let m = 334;
     let mut lhs: Matrix<Fr> = Vec::with_capacity(999);
     for _ in 0..m {
-        lhs.push(vec![ Fr::rand(&mut rng), Fr::rand(&mut rng) ]);
+        lhs.push(vec![Fr::rand(&mut rng), Fr::rand(&mut rng)]);
     }
     // 2 x 334 matrix
     let n = 334;
@@ -142,7 +125,7 @@ pub fn bench_large_field_matrix_mul_par(c: &mut Criterion) {
     for _ in 0..2 {
         let mut tmp: Vec<Fr> = Vec::with_capacity(n);
         for _ in 0..n {
-            tmp.push( Fr::rand(&mut rng) );
+            tmp.push(Fr::rand(&mut rng));
         }
         rhs.push(tmp);
     }
@@ -152,23 +135,28 @@ pub fn bench_large_field_matrix_mul_par(c: &mut Criterion) {
             bench.iter(|| {
                 let _ = lhs.right_mul(&rhs, true);
             });
-        }
+        },
     );
 }
 
 pub fn bench_small_B1_matrix_mul(c: &mut Criterion) {
-
     std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
     let mut rng = test_rng();
     let g1gen = G1Projective::rand(&mut rng).into_affine();
 
     let rhs: Matrix<Com1<F>> = vec![
-        vec![Com1::<F>( affine_group_rand!(g1gen, rng), affine_group_rand!(g1gen, rng) )],
-        vec![Com1::<F>( affine_group_rand!(g1gen, rng), affine_group_rand!(g1gen, rng) )]
+        vec![Com1::<F>(
+            affine_group_rand!(g1gen, rng),
+            affine_group_rand!(g1gen, rng),
+        )],
+        vec![Com1::<F>(
+            affine_group_rand!(g1gen, rng),
+            affine_group_rand!(g1gen, rng),
+        )],
     ];
     let lhs: Matrix<Fr> = vec![
-        vec![ Fr::rand(&mut rng), Fr::rand(&mut rng) ],
-        vec![ Fr::rand(&mut rng), Fr::rand(&mut rng) ]
+        vec![Fr::rand(&mut rng), Fr::rand(&mut rng)],
+        vec![Fr::rand(&mut rng), Fr::rand(&mut rng)],
     ];
     c.bench_function(
         &format!("sequential (2 x 2) Fp * (2 x 1) B1 matrix mult"),
@@ -176,23 +164,28 @@ pub fn bench_small_B1_matrix_mul(c: &mut Criterion) {
             bench.iter(|| {
                 let _ = rhs.left_mul(&lhs, false);
             });
-        }
+        },
     );
 }
 
 pub fn bench_small_B1_matrix_mul_par(c: &mut Criterion) {
-
     std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
     let mut rng = test_rng();
     let g1gen = G1Projective::rand(&mut rng).into_affine();
 
     let rhs: Matrix<Com1<F>> = vec![
-        vec![Com1::<F>( affine_group_rand!(g1gen, rng), affine_group_rand!(g1gen, rng) )],
-        vec![Com1::<F>( affine_group_rand!(g1gen, rng), affine_group_rand!(g1gen, rng) )]
+        vec![Com1::<F>(
+            affine_group_rand!(g1gen, rng),
+            affine_group_rand!(g1gen, rng),
+        )],
+        vec![Com1::<F>(
+            affine_group_rand!(g1gen, rng),
+            affine_group_rand!(g1gen, rng),
+        )],
     ];
     let lhs: Matrix<Fr> = vec![
-        vec![ Fr::rand(&mut rng), Fr::rand(&mut rng) ],
-        vec![ Fr::rand(&mut rng), Fr::rand(&mut rng) ]
+        vec![Fr::rand(&mut rng), Fr::rand(&mut rng)],
+        vec![Fr::rand(&mut rng), Fr::rand(&mut rng)],
     ];
     c.bench_function(
         &format!("concurrent (2 x 2) Fp * (2 x 1) B1 matrix mult"),
@@ -200,156 +193,120 @@ pub fn bench_small_B1_matrix_mul_par(c: &mut Criterion) {
             bench.iter(|| {
                 let _ = rhs.left_mul(&lhs, true);
             });
-        }
+        },
     );
 }
 
 fn bench_B1_scalar_mul(c: &mut Criterion) {
-
     std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
     let mut rng = test_rng();
     let g11 = G1Projective::rand(&mut rng).into_affine();
     let g12 = G1Projective::rand(&mut rng).into_affine();
-    let b1 = Com1::<F>( g11, g12 );
+    let b1 = Com1::<F>(g11, g12);
     let fr = Fr::rand(&mut rng);
 
-    c.bench_function(
-        &format!("B1 scalar mul"),
-        |bench| {
-            bench.iter(|| {
-                let _ = b1.scalar_mul(&fr);
-            });
-        }
-    );
+    c.bench_function(&format!("B1 scalar mul"), |bench| {
+        bench.iter(|| {
+            let _ = b1.scalar_mul(&fr);
+        });
+    });
 }
 
 fn bench_B1_add(c: &mut Criterion) {
-
     std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
     let mut rng = test_rng();
     let g11 = G1Projective::rand(&mut rng).into_affine();
     let g12 = G1Projective::rand(&mut rng).into_affine();
-    let b11 = Com1::<F>( g11, g12 );
+    let b11 = Com1::<F>(g11, g12);
     let g21 = G1Projective::rand(&mut rng).into_affine();
     let g22 = G1Projective::rand(&mut rng).into_affine();
-    let b12 = Com1::<F>( g21, g22 );
+    let b12 = Com1::<F>(g21, g22);
 
-    c.bench_function(
-        &format!("B1 add"),
-        |bench| {
-            bench.iter(|| {
-                let _ = b11 + b12;
-            });
-        }
-    );
+    c.bench_function(&format!("B1 add"), |bench| {
+        bench.iter(|| {
+            let _ = b11 + b12;
+        });
+    });
 }
 
 fn bench_G1_scalar_mul(c: &mut Criterion) {
-
     std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
     let mut rng = test_rng();
     let g1gen = G1Projective::rand(&mut rng).into_affine();
     let fr = Fr::rand(&mut rng);
 
-    c.bench_function(
-        &format!("G1 scalar mul"),
-        |bench| {
-            bench.iter(|| {
-                let _ = g1gen.mul(fr);
-            });
-        }
-    );
+    c.bench_function(&format!("G1 scalar mul"), |bench| {
+        bench.iter(|| {
+            let _ = g1gen.mul(fr);
+        });
+    });
 }
 
 fn bench_G1_affine_add(c: &mut Criterion) {
-
     std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
     let mut rng = test_rng();
     let g11 = G1Projective::rand(&mut rng).into_affine();
     let g12 = G1Projective::rand(&mut rng).into_affine();
 
-    c.bench_function(
-        &format!("G1 affine add"),
-        |bench| {
-            bench.iter(|| {
-                let _ = g11 + g12;
-            });
-        }
-    );
+    c.bench_function(&format!("G1 affine add"), |bench| {
+        bench.iter(|| {
+            let _ = g11 + g12;
+        });
+    });
 }
 
 fn bench_G1_projective_add(c: &mut Criterion) {
-
     std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
     let mut rng = test_rng();
     let g11 = G1Projective::rand(&mut rng);
     let g12 = G1Projective::rand(&mut rng);
 
-    c.bench_function(
-        &format!("G1 projective add"),
-        |bench| {
-            bench.iter(|| {
-                let _ = g11 + g12;
-            });
-        }
-    );
+    c.bench_function(&format!("G1 projective add"), |bench| {
+        bench.iter(|| {
+            let _ = g11 + g12;
+        });
+    });
 }
 
 fn bench_G1_into_affine(c: &mut Criterion) {
-
     std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
     let mut rng = test_rng();
     let g1gen = G1Projective::rand(&mut rng);
 
-    c.bench_function(
-        &format!("G1 projective into affine"),
-        |bench| {
-            bench.iter(|| {
-                let _ = g1gen.into_affine();
-            });
-        }
-    );
+    c.bench_function(&format!("G1 projective into affine"), |bench| {
+        bench.iter(|| {
+            let _ = g1gen.into_affine();
+        });
+    });
 }
 
 fn bench_G1_into_projective(c: &mut Criterion) {
-
     std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
     let mut rng = test_rng();
     let g1gen = G1Projective::rand(&mut rng).into_affine();
 
-    c.bench_function(
-        &format!("G1 affine into projective"),
-        |bench| {
-            bench.iter(|| {
-                let _ = g1gen.into_projective();
-            });
-        }
-    );
+    c.bench_function(&format!("G1 affine into projective"), |bench| {
+        bench.iter(|| {
+            let _ = g1gen.into_group();
+        });
+    });
 }
 
 fn bench_small_batch_commit_G1(c: &mut Criterion) {
-
     std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
     let mut rng = test_rng();
     let crs = CRS::<F>::generate_crs(&mut rng);
 
-    let xvars: Vec<G1Affine> = vec![
-        crs.g1_gen,
-        affine_group_new!(crs.g1_gen, "2")
-    ];
+    let xvars: Vec<G1Affine> = vec![crs.g1_gen, affine_group_new!(crs.g1_gen, "2")];
 
-    c.bench_function(
-        &format!("commit 2 G1"),
-        |bench| {
-            bench.iter(|| {
-                let _ = batch_commit_G1(&xvars, &crs, &mut rng);
-            });
-        }
-    );
+    c.bench_function(&format!("commit 2 G1"), |bench| {
+        bench.iter(|| {
+            let _ = batch_commit_G1(&xvars, &crs, &mut rng);
+        });
+    });
 }
 
 fn bench_large_batch_commit_G1(c: &mut Criterion) {
-
     std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
     let mut rng = test_rng();
     let crs = CRS::<F>::generate_crs(&mut rng);
@@ -360,39 +317,28 @@ fn bench_large_batch_commit_G1(c: &mut Criterion) {
         xvars.push(crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine());
     }
 
-    c.bench_function(
-        &format!("commit {} G1", m),
-        |bench| {
-            bench.iter(|| {
-                let _ = batch_commit_G1(&xvars, &crs, &mut rng);
-            });
-        }
-    );
+    c.bench_function(&format!("commit {} G1", m), |bench| {
+        bench.iter(|| {
+            let _ = batch_commit_G1(&xvars, &crs, &mut rng);
+        });
+    });
 }
 
 fn bench_small_batch_commit_G2(c: &mut Criterion) {
-
     std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
     let mut rng = test_rng();
     let crs = CRS::<F>::generate_crs(&mut rng);
 
-    let yvars: Vec<G2Affine> = vec![
-        crs.g2_gen,
-        affine_group_new!(crs.g2_gen, "2")
-    ];
+    let yvars: Vec<G2Affine> = vec![crs.g2_gen, affine_group_new!(crs.g2_gen, "2")];
 
-    c.bench_function(
-        &format!("commit 2 G2"),
-        |bench| {
-            bench.iter(|| {
-                let _ = batch_commit_G2(&yvars, &crs, &mut rng);
-            });
-        }
-    );
+    c.bench_function(&format!("commit 2 G2"), |bench| {
+        bench.iter(|| {
+            let _ = batch_commit_G2(&yvars, &crs, &mut rng);
+        });
+    });
 }
 
 fn bench_large_batch_commit_G2(c: &mut Criterion) {
-
     std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
     let mut rng = test_rng();
     let crs = CRS::<F>::generate_crs(&mut rng);
@@ -403,36 +349,28 @@ fn bench_large_batch_commit_G2(c: &mut Criterion) {
         yvars.push(crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine());
     }
 
-    c.bench_function(
-        &format!("commit {} G2", n),
-        |bench| {
-            bench.iter(|| {
-                let _ = batch_commit_G2(&yvars, &crs, &mut rng);
-            });
-        }
-    );
+    c.bench_function(&format!("commit {} G2", n), |bench| {
+        bench.iter(|| {
+            let _ = batch_commit_G2(&yvars, &crs, &mut rng);
+        });
+    });
 }
 
 fn bench_small_batch_commit_scalar_to_B1(c: &mut Criterion) {
-
     std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
     let mut rng = test_rng();
     let crs = CRS::<F>::generate_crs(&mut rng);
 
-    let scalar_xvars: Vec<Fr> = vec![ Fr::rand(&mut rng), Fr::rand(&mut rng) ];
+    let scalar_xvars: Vec<Fr> = vec![Fr::rand(&mut rng), Fr::rand(&mut rng)];
 
-    c.bench_function(
-        &format!("commit 2 scalar to B1"),
-        |bench| {
-            bench.iter(|| {
-                let _ = batch_commit_scalar_to_B1(&scalar_xvars, &crs, &mut rng);
-            });
-        }
-    );
+    c.bench_function(&format!("commit 2 scalar to B1"), |bench| {
+        bench.iter(|| {
+            let _ = batch_commit_scalar_to_B1(&scalar_xvars, &crs, &mut rng);
+        });
+    });
 }
 
 fn bench_large_batch_commit_scalar_to_B1(c: &mut Criterion) {
-
     std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
     let mut rng = test_rng();
     let crs = CRS::<F>::generate_crs(&mut rng);
@@ -443,36 +381,28 @@ fn bench_large_batch_commit_scalar_to_B1(c: &mut Criterion) {
         scalar_xvars.push(Fr::rand(&mut rng));
     }
 
-    c.bench_function(
-        &format!("commit {} scalar to B1", m),
-        |bench| {
-            bench.iter(|| {
-                let _ = batch_commit_scalar_to_B1(&scalar_xvars, &crs, &mut rng);
-            });
-        }
-    );
+    c.bench_function(&format!("commit {} scalar to B1", m), |bench| {
+        bench.iter(|| {
+            let _ = batch_commit_scalar_to_B1(&scalar_xvars, &crs, &mut rng);
+        });
+    });
 }
 
 fn bench_small_batch_commit_scalar_to_B2(c: &mut Criterion) {
-
     std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
     let mut rng = test_rng();
     let crs = CRS::<F>::generate_crs(&mut rng);
 
-    let scalar_yvars: Vec<Fr> = vec![ Fr::rand(&mut rng), Fr::rand(&mut rng) ];
+    let scalar_yvars: Vec<Fr> = vec![Fr::rand(&mut rng), Fr::rand(&mut rng)];
 
-    c.bench_function(
-        &format!("commit 2 scalar to B2"),
-        |bench| {
-            bench.iter(|| {
-                let _ = batch_commit_scalar_to_B2(&scalar_yvars, &crs, &mut rng);
-            });
-        }
-    );
+    c.bench_function(&format!("commit 2 scalar to B2"), |bench| {
+        bench.iter(|| {
+            let _ = batch_commit_scalar_to_B2(&scalar_yvars, &crs, &mut rng);
+        });
+    });
 }
 
 fn bench_large_batch_commit_scalar_to_B2(c: &mut Criterion) {
-
     std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
     let mut rng = test_rng();
     let crs = CRS::<F>::generate_crs(&mut rng);
@@ -483,38 +413,35 @@ fn bench_large_batch_commit_scalar_to_B2(c: &mut Criterion) {
         scalar_yvars.push(Fr::rand(&mut rng));
     }
 
-    c.bench_function(
-        &format!("commit {} scalar to B2", n),
-        |bench| {
-            bench.iter(|| {
-                let _ = batch_commit_scalar_to_B2(&scalar_yvars, &crs, &mut rng);
-            });
-        }
-    );
+    c.bench_function(&format!("commit {} scalar to B2", n), |bench| {
+        bench.iter(|| {
+            let _ = batch_commit_scalar_to_B2(&scalar_yvars, &crs, &mut rng);
+        });
+    });
 }
 
 fn bench_small_PPE_proof(c: &mut Criterion) {
-
     std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
     let mut rng = test_rng();
     let crs = CRS::<F>::generate_crs(&mut rng);
 
     let xvars: Vec<G1Affine> = vec![
         crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine(),
-        crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine()
+        crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine(),
     ];
-    let yvars: Vec<G2Affine> = vec![
-        crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine()
-    ];
+    let yvars: Vec<G2Affine> = vec![crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine()];
     let xcoms: Commit1<F> = batch_commit_G1(&xvars, &crs, &mut rng);
     let ycoms: Commit2<F> = batch_commit_G2(&yvars, &crs, &mut rng);
 
     let equ: PPE<F> = PPE::<F> {
         a_consts: vec![crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine()],
-        b_consts: vec![crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine(), crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine()],
+        b_consts: vec![
+            crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine(),
+            crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine(),
+        ],
         gamma: vec![vec![Fr::one()], vec![Fr::zero()]],
         // NOTE: dummy variable for this bench
-        target: Fqk::rand(&mut rng)
+        target: Fqk::rand(&mut rng),
     };
 
     c.bench_function(
@@ -523,12 +450,11 @@ fn bench_small_PPE_proof(c: &mut Criterion) {
             bench.iter(|| {
                 let _ = equ.prove(&xvars, &yvars, &xcoms, &ycoms, &crs, &mut rng);
             });
-        }
+        },
     );
 }
 
 fn bench_large_PPE_proof(c: &mut Criterion) {
-
     std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
     let mut rng = test_rng();
     let crs = CRS::<F>::generate_crs(&mut rng);
@@ -564,7 +490,7 @@ fn bench_large_PPE_proof(c: &mut Criterion) {
         b_consts,
         gamma,
         // NOTE: dummy variable for this bench
-        target: Fqk::rand(&mut rng)
+        target: Fqk::rand(&mut rng),
     };
 
     c.bench_function(
@@ -573,30 +499,30 @@ fn bench_large_PPE_proof(c: &mut Criterion) {
             bench.iter(|| {
                 let _ = equ.prove(&xvars, &yvars, &xcoms, &ycoms, &crs, &mut rng);
             });
-        }
+        },
     );
 }
 
 fn bench_small_PPE_verify(c: &mut Criterion) {
-
     std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
     let mut rng = test_rng();
     let crs = CRS::<F>::generate_crs(&mut rng);
 
     let xvars: Vec<G1Affine> = vec![
         crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine(),
-        crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine()
+        crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine(),
     ];
-    let yvars: Vec<G2Affine> = vec![
-        crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine()
-    ];
+    let yvars: Vec<G2Affine> = vec![crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine()];
 
     let equ: PPE<F> = PPE::<F> {
         a_consts: vec![crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine()],
-        b_consts: vec![crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine(), crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine()],
+        b_consts: vec![
+            crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine(),
+            crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine(),
+        ],
         gamma: vec![vec![Fr::one()], vec![Fr::zero()]],
         // NOTE: dummy variable for this bench
-        target: Fqk::rand(&mut rng)
+        target: Fqk::rand(&mut rng),
     };
 
     let proof: CProof<F> = equ.commit_and_prove(&xvars, &yvars, &crs, &mut rng);
@@ -607,12 +533,11 @@ fn bench_small_PPE_verify(c: &mut Criterion) {
             bench.iter(|| {
                 let _ = equ.verify(&proof, &crs);
             });
-        }
+        },
     );
 }
 
 fn bench_large_PPE_verify(c: &mut Criterion) {
-
     std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
     let mut rng = test_rng();
     let crs = CRS::<F>::generate_crs(&mut rng);
@@ -646,7 +571,7 @@ fn bench_large_PPE_verify(c: &mut Criterion) {
         b_consts,
         gamma,
         // NOTE: dummy variable for this bench
-        target: Fqk::rand(&mut rng)
+        target: Fqk::rand(&mut rng),
     };
 
     let proof: CProof<F> = equ.commit_and_prove(&xvars, &yvars, &crs, &mut rng);
@@ -657,25 +582,25 @@ fn bench_large_PPE_verify(c: &mut Criterion) {
             bench.iter(|| {
                 let _ = equ.verify(&proof, &crs);
             });
-        }
+        },
     );
 }
 
-criterion_group!{
+criterion_group! {
     name = small_field_matrix_mul;
     config = Criterion::default().sample_size(100);
     targets =
         bench_small_field_matrix_mul,
         bench_small_field_matrix_mul_par,
 }
-criterion_group!{
+criterion_group! {
     name = large_field_matrix_mul;
     config = Criterion::default().sample_size(25);
     targets =
         bench_large_field_matrix_mul,
         bench_large_field_matrix_mul_par
 }
-criterion_group!{
+criterion_group! {
     name = small_B1_matrix_mul;
     config = Criterion::default().sample_size(25);
     targets =
@@ -684,7 +609,7 @@ criterion_group!{
 }
 // operations in G2/B2 are ~4x that of G1/B1, respectively
 
-criterion_group!{
+criterion_group! {
     name = G1_arith;
     config = Criterion::default().sample_size(100);
     targets =
@@ -697,7 +622,7 @@ criterion_group!{
         bench_B1_scalar_mul
 }
 
-criterion_group!{
+criterion_group! {
     name = small_commit;
     config = Criterion::default().sample_size(50).measurement_time(Duration::new(10, 0));
     targets =
@@ -707,7 +632,7 @@ criterion_group!{
         bench_small_batch_commit_scalar_to_B2,
 }
 
-criterion_group!{
+criterion_group! {
     name = large_commit;
     config = Criterion::default().sample_size(10).measurement_time(Duration::new(20, 0));
     targets =
@@ -717,26 +642,26 @@ criterion_group!{
         bench_large_batch_commit_scalar_to_B2
 }
 
-criterion_group!{
+criterion_group! {
     name = small_prove;
     config = Criterion::default().sample_size(200);
     targets =
         bench_small_PPE_proof,
 }
-criterion_group!{
+criterion_group! {
     name = large_prove;
     config = Criterion::default().sample_size(20).measurement_time(Duration::new(30, 0));
     targets =
         bench_large_PPE_proof
 }
 
-criterion_group!{
+criterion_group! {
     name = small_ver;
     config = Criterion::default().sample_size(200).measurement_time(Duration::new(20, 0));
     targets =
         bench_small_PPE_verify,
 }
-criterion_group!{
+criterion_group! {
     name = large_ver;
     config = Criterion::default().sample_size(10).measurement_time(Duration::new(300, 0));
     targets =
@@ -744,14 +669,14 @@ criterion_group!{
 }
 
 criterion_main!(
-//    small_field_matrix_mul,
-//    large_field_matrix_mul,
-//    small_B1_matrix_mul,
-//    G1_arith
+    //    small_field_matrix_mul,
+    //    large_field_matrix_mul,
+    //    small_B1_matrix_mul,
+    //    G1_arith
     small_commit,
     large_commit,
     small_prove,
     large_prove,
     small_ver,
-//    large_ver
+    //    large_ver
 );

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -48,14 +48,11 @@ pub fn bench_small_field_matrix_mul(c: &mut Criterion) {
     ];
     // 2 x 1 matrix
     let rhs: Matrix<Fr> = vec![vec![Fr::rand(&mut rng)], vec![Fr::rand(&mut rng)]];
-    c.bench_function(
-        &format!("sequential (2 x 2) * (2 x 1) field matrix mult"),
-        |bench| {
-            bench.iter(|| {
-                let _ = lhs.right_mul(&rhs, false);
-            });
-        },
-    );
+    c.bench_function("sequential (2 x 2) * (2 x 1) field matrix mult", |bench| {
+        bench.iter(|| {
+            let _ = lhs.right_mul(&rhs, false);
+        });
+    });
 }
 
 pub fn bench_small_field_matrix_mul_par(c: &mut Criterion) {
@@ -69,14 +66,11 @@ pub fn bench_small_field_matrix_mul_par(c: &mut Criterion) {
     ];
     // 2 x 1 matrix
     let rhs: Matrix<Fr> = vec![vec![Fr::rand(&mut rng)], vec![Fr::rand(&mut rng)]];
-    c.bench_function(
-        &format!("concurrent (2 x 2) * (2 x 1) field matrix mult"),
-        |bench| {
-            bench.iter(|| {
-                let _ = lhs.right_mul(&rhs, true);
-            });
-        },
-    );
+    c.bench_function("concurrent (2 x 2) * (2 x 1) field matrix mult", |bench| {
+        bench.iter(|| {
+            let _ = lhs.right_mul(&rhs, true);
+        });
+    });
 }
 
 pub fn bench_large_field_matrix_mul(c: &mut Criterion) {
@@ -158,14 +152,11 @@ pub fn bench_small_B1_matrix_mul(c: &mut Criterion) {
         vec![Fr::rand(&mut rng), Fr::rand(&mut rng)],
         vec![Fr::rand(&mut rng), Fr::rand(&mut rng)],
     ];
-    c.bench_function(
-        &format!("sequential (2 x 2) Fp * (2 x 1) B1 matrix mult"),
-        |bench| {
-            bench.iter(|| {
-                let _ = rhs.left_mul(&lhs, false);
-            });
-        },
-    );
+    c.bench_function("sequential (2 x 2) Fp * (2 x 1) B1 matrix mult", |bench| {
+        bench.iter(|| {
+            let _ = rhs.left_mul(&lhs, false);
+        });
+    });
 }
 
 pub fn bench_small_B1_matrix_mul_par(c: &mut Criterion) {
@@ -187,14 +178,11 @@ pub fn bench_small_B1_matrix_mul_par(c: &mut Criterion) {
         vec![Fr::rand(&mut rng), Fr::rand(&mut rng)],
         vec![Fr::rand(&mut rng), Fr::rand(&mut rng)],
     ];
-    c.bench_function(
-        &format!("concurrent (2 x 2) Fp * (2 x 1) B1 matrix mult"),
-        |bench| {
-            bench.iter(|| {
-                let _ = rhs.left_mul(&lhs, true);
-            });
-        },
-    );
+    c.bench_function("concurrent (2 x 2) Fp * (2 x 1) B1 matrix mult", |bench| {
+        bench.iter(|| {
+            let _ = rhs.left_mul(&lhs, true);
+        });
+    });
 }
 
 fn bench_B1_scalar_mul(c: &mut Criterion) {
@@ -205,7 +193,7 @@ fn bench_B1_scalar_mul(c: &mut Criterion) {
     let b1 = Com1::<F>(g11, g12);
     let fr = Fr::rand(&mut rng);
 
-    c.bench_function(&format!("B1 scalar mul"), |bench| {
+    c.bench_function("B1 scalar mul", |bench| {
         bench.iter(|| {
             let _ = b1.scalar_mul(&fr);
         });
@@ -222,7 +210,7 @@ fn bench_B1_add(c: &mut Criterion) {
     let g22 = G1Projective::rand(&mut rng).into_affine();
     let b12 = Com1::<F>(g21, g22);
 
-    c.bench_function(&format!("B1 add"), |bench| {
+    c.bench_function("B1 add", |bench| {
         bench.iter(|| {
             let _ = b11 + b12;
         });
@@ -235,7 +223,7 @@ fn bench_G1_scalar_mul(c: &mut Criterion) {
     let g1gen = G1Projective::rand(&mut rng).into_affine();
     let fr = Fr::rand(&mut rng);
 
-    c.bench_function(&format!("G1 scalar mul"), |bench| {
+    c.bench_function("G1 scalar mul", |bench| {
         bench.iter(|| {
             let _ = g1gen.mul(fr);
         });
@@ -248,7 +236,7 @@ fn bench_G1_affine_add(c: &mut Criterion) {
     let g11 = G1Projective::rand(&mut rng).into_affine();
     let g12 = G1Projective::rand(&mut rng).into_affine();
 
-    c.bench_function(&format!("G1 affine add"), |bench| {
+    c.bench_function("G1 affine add", |bench| {
         bench.iter(|| {
             let _ = g11 + g12;
         });
@@ -261,7 +249,7 @@ fn bench_G1_projective_add(c: &mut Criterion) {
     let g11 = G1Projective::rand(&mut rng);
     let g12 = G1Projective::rand(&mut rng);
 
-    c.bench_function(&format!("G1 projective add"), |bench| {
+    c.bench_function("G1 projective add", |bench| {
         bench.iter(|| {
             let _ = g11 + g12;
         });
@@ -273,7 +261,7 @@ fn bench_G1_into_affine(c: &mut Criterion) {
     let mut rng = test_rng();
     let g1gen = G1Projective::rand(&mut rng);
 
-    c.bench_function(&format!("G1 projective into affine"), |bench| {
+    c.bench_function("G1 projective into affine", |bench| {
         bench.iter(|| {
             let _ = g1gen.into_affine();
         });
@@ -285,7 +273,7 @@ fn bench_G1_into_projective(c: &mut Criterion) {
     let mut rng = test_rng();
     let g1gen = G1Projective::rand(&mut rng).into_affine();
 
-    c.bench_function(&format!("G1 affine into projective"), |bench| {
+    c.bench_function("G1 affine into projective", |bench| {
         bench.iter(|| {
             let _ = g1gen.into_group();
         });
@@ -299,7 +287,7 @@ fn bench_small_batch_commit_G1(c: &mut Criterion) {
 
     let xvars: Vec<G1Affine> = vec![crs.g1_gen, affine_group_new!(crs.g1_gen, "2")];
 
-    c.bench_function(&format!("commit 2 G1"), |bench| {
+    c.bench_function("commit 2 G1", |bench| {
         bench.iter(|| {
             let _ = batch_commit_G1(&xvars, &crs, &mut rng);
         });
@@ -331,7 +319,7 @@ fn bench_small_batch_commit_G2(c: &mut Criterion) {
 
     let yvars: Vec<G2Affine> = vec![crs.g2_gen, affine_group_new!(crs.g2_gen, "2")];
 
-    c.bench_function(&format!("commit 2 G2"), |bench| {
+    c.bench_function("commit 2 G2", |bench| {
         bench.iter(|| {
             let _ = batch_commit_G2(&yvars, &crs, &mut rng);
         });
@@ -363,7 +351,7 @@ fn bench_small_batch_commit_scalar_to_B1(c: &mut Criterion) {
 
     let scalar_xvars: Vec<Fr> = vec![Fr::rand(&mut rng), Fr::rand(&mut rng)];
 
-    c.bench_function(&format!("commit 2 scalar to B1"), |bench| {
+    c.bench_function("commit 2 scalar to B1", |bench| {
         bench.iter(|| {
             let _ = batch_commit_scalar_to_B1(&scalar_xvars, &crs, &mut rng);
         });
@@ -395,7 +383,7 @@ fn bench_small_batch_commit_scalar_to_B2(c: &mut Criterion) {
 
     let scalar_yvars: Vec<Fr> = vec![Fr::rand(&mut rng), Fr::rand(&mut rng)];
 
-    c.bench_function(&format!("commit 2 scalar to B2"), |bench| {
+    c.bench_function("commit 2 scalar to B2", |bench| {
         bench.iter(|| {
             let _ = batch_commit_scalar_to_B2(&scalar_yvars, &crs, &mut rng);
         });
@@ -444,14 +432,11 @@ fn bench_small_PPE_proof(c: &mut Criterion) {
         target: Fqk::rand(&mut rng),
     };
 
-    c.bench_function(
-        &format!("prove PPE equation with 2 G1 vars, 1 G2 var"),
-        |bench| {
-            bench.iter(|| {
-                let _ = equ.prove(&xvars, &yvars, &xcoms, &ycoms, &crs, &mut rng);
-            });
-        },
-    );
+    c.bench_function("prove PPE equation with 2 G1 vars, 1 G2 var", |bench| {
+        bench.iter(|| {
+            let _ = equ.prove(&xvars, &yvars, &xcoms, &ycoms, &crs, &mut rng);
+        });
+    });
 }
 
 fn bench_large_PPE_proof(c: &mut Criterion) {
@@ -527,14 +512,11 @@ fn bench_small_PPE_verify(c: &mut Criterion) {
 
     let proof: CProof<F> = equ.commit_and_prove(&xvars, &yvars, &crs, &mut rng);
 
-    c.bench_function(
-        &format!("verify PPE equation with 2 G1 vars, 1 G2 var"),
-        |bench| {
-            bench.iter(|| {
-                let _ = equ.verify(&proof, &crs);
-            });
-        },
-    );
+    c.bench_function("verify PPE equation with 2 G1 vars, 1 G2 var", |bench| {
+        bench.iter(|| {
+            let _ = equ.verify(&proof, &crs);
+        });
+    });
 }
 
 fn bench_large_PPE_verify(c: &mut Criterion) {

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,8 +1,6 @@
 #![allow(non_snake_case)]
 #![allow(dead_code)]
 
-extern crate groth_sahai;
-
 use criterion::{criterion_group, criterion_main, Criterion};
 
 use std::time::Duration;

--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -74,10 +74,10 @@ pub trait B1<E: Pairing>:
     fn as_vec(&self) -> Vec<E::G1Affine>;
     /// The linear map from G1 to B1 for pairing-product and multi-scalar multiplication equations.
     fn linear_map(x: &E::G1Affine) -> Self;
-    fn batch_linear_map(x_vec: &Vec<E::G1Affine>) -> Vec<Self>;
+    fn batch_linear_map(x_vec: &[E::G1Affine]) -> Vec<Self>;
     /// The linear map from scalar field to B1 for multi-scalar multiplication and quadratic equations.
     fn scalar_linear_map(x: &E::ScalarField, key: &CRS<E>) -> Self;
-    fn batch_scalar_linear_map(x_vec: &Vec<E::ScalarField>, key: &CRS<E>) -> Vec<Self>;
+    fn batch_scalar_linear_map(x_vec: &[E::ScalarField], key: &CRS<E>) -> Vec<Self>;
 
     fn scalar_mul(&self, other: &E::ScalarField) -> Self;
 }
@@ -92,10 +92,10 @@ pub trait B2<E: Pairing>:
     fn as_vec(&self) -> Vec<E::G2Affine>;
     /// The linear map from G2 to B2 for pairing-product and multi-scalar multiplication equations.
     fn linear_map(y: &E::G2Affine) -> Self;
-    fn batch_linear_map(y_vec: &Vec<E::G2Affine>) -> Vec<Self>;
+    fn batch_linear_map(y_vec: &[E::G2Affine]) -> Vec<Self>;
     /// The linear map from scalar field to B2 for multi-scalar multiplication and quadratic equations.
     fn scalar_linear_map(y: &E::ScalarField, key: &CRS<E>) -> Self;
-    fn batch_scalar_linear_map(y_vec: &Vec<E::ScalarField>, key: &CRS<E>) -> Vec<Self>;
+    fn batch_scalar_linear_map(y_vec: &[E::ScalarField], key: &CRS<E>) -> Vec<Self>;
 
     fn scalar_mul(&self, other: &E::ScalarField) -> Self;
 }
@@ -108,7 +108,7 @@ pub trait BT<E: Pairing, C1: B1<E>, C2: B2<E>>: B<E> + From<Matrix<E::TargetFiel
     /// with respect to the bilinear pairing over the bilinear group (G1, G2, GT).
     fn pairing(x: C1, y: C2) -> Self;
     /// The entry-wise sum of bilinear pairings over the GS commitment group.
-    fn pairing_sum(x_vec: &Vec<C1>, y_vec: &Vec<C2>) -> Self;
+    fn pairing_sum(x_vec: &[C1], y_vec: &[C2]) -> Self;
 
     /// The linear map from GT to BT for pairing-product equations.
     #[allow(non_snake_case)]
@@ -161,7 +161,7 @@ pub fn col_vec_to_vec<F: Clone>(mat: &Matrix<F>) -> Vec<F> {
 }
 
 /// Expand vector into column vector (in matrix form).
-pub fn vec_to_col_vec<F: Clone>(vec: &Vec<F>) -> Matrix<F> {
+pub fn vec_to_col_vec<F: Clone>(vec: &[F]) -> Matrix<F> {
     let mut mat = Vec::with_capacity(vec.len());
     for elem in vec.iter() {
         mat.push(vec![elem.clone()]);
@@ -322,7 +322,7 @@ impl<E: Pairing> B1<E> for Com1<E> {
     }
 
     #[inline]
-    fn batch_linear_map(x_vec: &Vec<E::G1Affine>) -> Vec<Self> {
+    fn batch_linear_map(x_vec: &[E::G1Affine]) -> Vec<Self> {
         x_vec
             .iter()
             .map(|elem| Self::linear_map(elem))
@@ -336,7 +336,7 @@ impl<E: Pairing> B1<E> for Com1<E> {
     }
 
     #[inline]
-    fn batch_scalar_linear_map(x_vec: &Vec<E::ScalarField>, key: &CRS<E>) -> Vec<Self> {
+    fn batch_scalar_linear_map(x_vec: &[E::ScalarField], key: &CRS<E>) -> Vec<Self> {
         x_vec
             .iter()
             .map(|elem| Self::scalar_linear_map(elem, key))
@@ -367,7 +367,7 @@ impl<E: Pairing> B2<E> for Com2<E> {
     }
 
     #[inline]
-    fn batch_linear_map(y_vec: &Vec<E::G2Affine>) -> Vec<Self> {
+    fn batch_linear_map(y_vec: &[E::G2Affine]) -> Vec<Self> {
         y_vec
             .iter()
             .map(|elem| Self::linear_map(elem))
@@ -381,7 +381,7 @@ impl<E: Pairing> B2<E> for Com2<E> {
     }
 
     #[inline]
-    fn batch_scalar_linear_map(y_vec: &Vec<E::ScalarField>, key: &CRS<E>) -> Vec<Self> {
+    fn batch_scalar_linear_map(y_vec: &[E::ScalarField], key: &CRS<E>) -> Vec<Self> {
         y_vec
             .iter()
             .map(|elem| Self::scalar_linear_map(elem, key))
@@ -510,7 +510,7 @@ impl<E: Pairing> BT<E, Com1<E>, Com2<E>> for ComT<E> {
     }
 
     #[inline]
-    fn pairing_sum(x_vec: &Vec<Com1<E>>, y_vec: &Vec<Com2<E>>) -> ComT<E> {
+    fn pairing_sum(x_vec: &[Com1<E>], y_vec: &[Com2<E>]) -> ComT<E> {
         assert_eq!(x_vec.len(), y_vec.len());
         let xy_vec = x_vec
             .iter()

--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -31,7 +31,7 @@ use ark_std::{
 };
 use rayon::prelude::*;
 
-use crate::generator::*;
+use crate::generator::CRS;
 
 pub trait Mat<Elem: Clone>: Eq + Clone + Debug {
     type Other;
@@ -963,17 +963,24 @@ impl<F: Field> Mat<F> for Matrix<F> {
 
 #[cfg(test)]
 mod tests {
-
     #![allow(non_snake_case)]
+
+    use super::*;
+
     mod SXDH_com_group {
 
         use ark_bls12_381::Bls12_381 as F;
-        use ark_ec::{AffineRepr, CurveGroup};
+        use ark_ec::{
+            pairing::{Pairing, PairingOutput},
+            AffineRepr, CurveGroup,
+        };
         use ark_ff::UniformRand;
         use ark_std::ops::Mul;
         use ark_std::test_rng;
 
-        use crate::data_structures::*;
+        use crate::AbstractCrs;
+
+        use super::*;
 
         type G1Affine = <F as Pairing>::G1Affine;
         type G1Projective = <F as Pairing>::G1;
@@ -1609,7 +1616,7 @@ mod tests {
         use ark_std::str::FromStr;
         use ark_std::test_rng;
 
-        use crate::data_structures::*;
+        use super::*;
 
         type G1Affine = <F as Pairing>::G1Affine;
         type G1Projective = <F as Pairing>::G1;

--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -318,7 +318,7 @@ impl<E: Pairing> B1<E> for Com1<E> {
 
     #[inline]
     fn linear_map(x: &E::G1Affine) -> Self {
-        Self(E::G1Affine::zero(), x.clone())
+        Self(E::G1Affine::zero(), *x)
     }
 
     #[inline]
@@ -344,11 +344,11 @@ impl<E: Pairing> B1<E> for Com1<E> {
     }
 
     fn scalar_mul(&self, rhs: &E::ScalarField) -> Self {
-        let mut s1p = self.0.clone().into_group();
-        let mut s2p = self.1.clone().into_group();
+        let mut s1p = self.0.into_group();
+        let mut s2p = self.1.into_group();
         s1p *= *rhs;
         s2p *= *rhs;
-        Self(s1p.into_affine().clone(), s2p.into_affine().clone())
+        Self(s1p.into_affine(), s2p.into_affine())
     }
 }
 
@@ -363,7 +363,7 @@ impl<E: Pairing> B2<E> for Com2<E> {
 
     #[inline]
     fn linear_map(y: &E::G2Affine) -> Self {
-        Self(E::G2Affine::zero(), y.clone())
+        Self(E::G2Affine::zero(), *y)
     }
 
     #[inline]
@@ -389,11 +389,11 @@ impl<E: Pairing> B2<E> for Com2<E> {
     }
 
     fn scalar_mul(&self, rhs: &E::ScalarField) -> Self {
-        let mut s1p = self.0.clone().into_group();
-        let mut s2p = self.1.clone().into_group();
+        let mut s1p = self.0.into_group();
+        let mut s2p = self.1.into_group();
         s1p *= *rhs;
         s2p *= *rhs;
-        Self(s1p.into_affine().clone(), s2p.into_affine().clone())
+        Self(s1p.into_affine(), s2p.into_affine())
     }
 }
 
@@ -502,10 +502,10 @@ impl<E: Pairing> BT<E, Com1<E>, Com2<E>> for ComT<E> {
     #[inline]
     fn pairing(x: Com1<E>, y: Com2<E>) -> ComT<E> {
         ComT::<E>(
-            E::pairing(x.0.clone(), y.0.clone()).0,
-            E::pairing(x.0.clone(), y.1.clone()).0,
-            E::pairing(x.1.clone(), y.0.clone()).0,
-            E::pairing(x.1.clone(), y.1.clone()).0,
+            E::pairing(x.0, y.0).0,
+            E::pairing(x.0, y.1).0,
+            E::pairing(x.1, y.0).0,
+            E::pairing(x.1, y.1).0,
         )
     }
 
@@ -530,7 +530,7 @@ impl<E: Pairing> BT<E, Com1<E>, Com2<E>> for ComT<E> {
             E::TargetField::one(),
             E::TargetField::one(),
             E::TargetField::one(),
-            z.clone(),
+            *z,
         )
     }
 
@@ -826,7 +826,7 @@ impl<F: Field> Mat<F> for Matrix<F> {
         for i in 0..m {
             add.push(Vec::with_capacity(n));
             for j in 0..n {
-                add[i].push(self[i][j].clone() + other[i][j].clone());
+                add[i].push(self[i][j] + other[i][j]);
             }
         }
         add
@@ -864,7 +864,7 @@ impl<F: Field> Mat<F> for Matrix<F> {
         for row in self {
             for i in 0..row.len() {
                 // Push rows onto columns
-                trans[i].push(row[i].clone());
+                trans[i].push(row[i]);
             }
         }
         trans
@@ -1335,7 +1335,7 @@ mod tests {
                 G2Projective::rand(&mut rng).into_affine(),
                 G2Projective::rand(&mut rng).into_affine(),
             );
-            let bt = ComT::pairing(b1.clone(), b2.clone());
+            let bt = ComT::pairing(b1, b2);
 
             assert_eq!(bt.0, Fqk::one());
             assert_eq!(bt.1, Fqk::one());
@@ -1352,7 +1352,7 @@ mod tests {
                 G1Projective::rand(&mut rng).into_affine(),
             );
             let b2 = Com2::<F>(G2Affine::zero(), G2Affine::zero());
-            let bt = ComT::pairing(b1.clone(), b2.clone());
+            let bt = ComT::pairing(b1, b2);
 
             assert_eq!(bt.0, Fqk::one());
             assert_eq!(bt.1, Fqk::one());
@@ -1366,12 +1366,12 @@ mod tests {
             let mut rng = test_rng();
             let b1 = Com1::<F>(G1Affine::zero(), G1Projective::rand(&mut rng).into_affine());
             let b2 = Com2::<F>(G2Affine::zero(), G2Projective::rand(&mut rng).into_affine());
-            let bt = ComT::pairing(b1.clone(), b2.clone());
+            let bt = ComT::pairing(b1, b2);
 
             assert_eq!(bt.0, Fqk::one());
             assert_eq!(bt.1, Fqk::one());
             assert_eq!(bt.2, Fqk::one());
-            assert_eq!(bt.3, F::pairing(b1.1.clone(), b2.1.clone()).0);
+            assert_eq!(bt.3, F::pairing(b1.1, b2.1).0);
         }
 
         #[allow(non_snake_case)]
@@ -1386,12 +1386,12 @@ mod tests {
                 G2Projective::rand(&mut rng).into_affine(),
                 G2Projective::rand(&mut rng).into_affine(),
             );
-            let bt = ComT::pairing(b1.clone(), b2.clone());
+            let bt = ComT::pairing(b1, b2);
 
-            assert_eq!(bt.0, F::pairing(b1.0.clone(), b2.0.clone()).0);
-            assert_eq!(bt.1, F::pairing(b1.0.clone(), b2.1.clone()).0);
-            assert_eq!(bt.2, F::pairing(b1.1.clone(), b2.0.clone()).0);
-            assert_eq!(bt.3, F::pairing(b1.1.clone(), b2.1.clone()).0);
+            assert_eq!(bt.0, F::pairing(b1.0, b2.0).0);
+            assert_eq!(bt.1, F::pairing(b1.0, b2.1).0);
+            assert_eq!(bt.2, F::pairing(b1.1, b2.0).0);
+            assert_eq!(bt.3, F::pairing(b1.1, b2.1).0);
         }
 
         #[allow(non_snake_case)]
@@ -1435,7 +1435,7 @@ mod tests {
                 G2Projective::rand(&mut rng).into_affine(),
                 G2Projective::rand(&mut rng).into_affine(),
             );
-            let bt = ComT::pairing(b1.clone(), b2.clone());
+            let bt = ComT::pairing(b1, b2);
 
             // B1 and B2 can be representing as 2-dim column vectors
             assert_eq!(b1.as_col_vec(), vec![vec![b1.0], vec![b1.1]]);
@@ -1458,12 +1458,12 @@ mod tests {
             ];
             let bt_vec = vec![
                 vec![
-                    F::pairing(b1_vec[0][0].clone(), b2_vec[0][0].clone()).0,
-                    F::pairing(b1_vec[0][0].clone(), b2_vec[1][0].clone()).0,
+                    F::pairing(b1_vec[0][0], b2_vec[0][0]).0,
+                    F::pairing(b1_vec[0][0], b2_vec[1][0]).0,
                 ],
                 vec![
-                    F::pairing(b1_vec[1][0].clone(), b2_vec[0][0].clone()).0,
-                    F::pairing(b1_vec[1][0].clone(), b2_vec[1][0].clone()).0,
+                    F::pairing(b1_vec[1][0], b2_vec[0][0]).0,
+                    F::pairing(b1_vec[1][0], b2_vec[1][0]).0,
                 ],
             ];
 
@@ -1533,7 +1533,7 @@ mod tests {
             let mut rng = test_rng();
             let a1 = G1Projective::rand(&mut rng).into_affine();
             let a2 = G2Projective::rand(&mut rng).into_affine();
-            let at = F::pairing(a1.clone(), a2.clone()).0;
+            let at = F::pairing(a1, a2).0;
             let b1 = Com1::<F>::linear_map(&a1);
             let b2 = Com2::<F>::linear_map(&a2);
             let bt = ComT::<F>::linear_map_PPE(&at);
@@ -1545,7 +1545,7 @@ mod tests {
             assert_eq!(bt.0, Fqk::one());
             assert_eq!(bt.1, Fqk::one());
             assert_eq!(bt.2, Fqk::one());
-            assert_eq!(bt.3, F::pairing(a1.clone(), a2.clone()).0);
+            assert_eq!(bt.3, F::pairing(a1, a2).0);
         }
 
         // Test that we're using the linear map that preserves witness-indistinguishability (see Ghadafi et al. 2010)
@@ -1567,11 +1567,8 @@ mod tests {
             assert_eq!(b2.1, (key.v[1].1 + key.g2_gen).mul(a2));
             assert_eq!(bt.0, Fqk::one());
             assert_eq!(bt.1, Fqk::one());
-            assert_eq!(bt.2, F::pairing(at.clone(), key.v[1].0.clone()).0);
-            assert_eq!(
-                bt.3,
-                F::pairing(at.clone(), key.v[1].1.clone() + key.g2_gen.clone()).0
-            );
+            assert_eq!(bt.2, F::pairing(at, key.v[1].0).0);
+            assert_eq!(bt.3, F::pairing(at, key.v[1].1 + key.g2_gen).0);
         }
 
         // Test that we're using the linear map that preserves witness-indistinguishability (see Ghadafi et al. 2010)
@@ -1592,12 +1589,9 @@ mod tests {
             assert_eq!(b2.0, G2Affine::zero());
             assert_eq!(b2.1, a2);
             assert_eq!(bt.0, Fqk::one());
-            assert_eq!(bt.1, F::pairing(key.u[1].0.clone(), at.clone()).0);
+            assert_eq!(bt.1, F::pairing(key.u[1].0, at).0);
             assert_eq!(bt.2, Fqk::one());
-            assert_eq!(
-                bt.3,
-                F::pairing(key.u[1].1.clone() + key.g1_gen.clone(), at.clone()).0
-            );
+            assert_eq!(bt.3, F::pairing(key.u[1].1 + key.g1_gen, at).0);
         }
 
         // Test that we're using the linear map that preserves witness-indistinguishability (see Ghadafi et al. 2010)

--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -513,7 +513,7 @@ impl<E: Pairing> BT<E, Com1<E>, Com2<E>> for ComT<E> {
     fn pairing_sum(x_vec: &Vec<Com1<E>>, y_vec: &Vec<Com2<E>>) -> ComT<E> {
         assert_eq!(x_vec.len(), y_vec.len());
         let xy_vec = x_vec
-            .into_iter()
+            .iter()
             .zip(y_vec)
             .collect::<Vec<(&Com1<E>, &Com2<E>)>>();
 

--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -324,22 +324,22 @@ impl<E: Pairing> B1<E> for Com1<E> {
     #[inline]
     fn batch_linear_map(x_vec: &Vec<E::G1Affine>) -> Vec<Self> {
         x_vec
-            .into_iter()
-            .map(|elem| Self::linear_map(&elem))
+            .iter()
+            .map(|elem| Self::linear_map(elem))
             .collect::<Vec<Self>>()
     }
 
     #[inline]
     fn scalar_linear_map(x: &E::ScalarField, key: &CRS<E>) -> Self {
         // = xu, where u = u_2 + (O, P) is a commitment group element
-        (key.u[1] + Com1::<E>::linear_map(&key.g1_gen)).scalar_mul(&x)
+        (key.u[1] + Com1::<E>::linear_map(&key.g1_gen)).scalar_mul(x)
     }
 
     #[inline]
     fn batch_scalar_linear_map(x_vec: &Vec<E::ScalarField>, key: &CRS<E>) -> Vec<Self> {
         x_vec
-            .into_iter()
-            .map(|elem| Self::scalar_linear_map(&elem, key))
+            .iter()
+            .map(|elem| Self::scalar_linear_map(elem, key))
             .collect::<Vec<Self>>()
     }
 
@@ -369,22 +369,22 @@ impl<E: Pairing> B2<E> for Com2<E> {
     #[inline]
     fn batch_linear_map(y_vec: &Vec<E::G2Affine>) -> Vec<Self> {
         y_vec
-            .into_iter()
-            .map(|elem| Self::linear_map(&elem))
+            .iter()
+            .map(|elem| Self::linear_map(elem))
             .collect::<Vec<Self>>()
     }
 
     #[inline]
     fn scalar_linear_map(y: &E::ScalarField, key: &CRS<E>) -> Self {
         // = yv, where v = v_2 + (O, P) is a commitment group element
-        (key.v[1] + Com2::<E>::linear_map(&key.g2_gen)).scalar_mul(&y)
+        (key.v[1] + Com2::<E>::linear_map(&key.g2_gen)).scalar_mul(y)
     }
 
     #[inline]
     fn batch_scalar_linear_map(y_vec: &Vec<E::ScalarField>, key: &CRS<E>) -> Vec<Self> {
         y_vec
-            .into_iter()
-            .map(|elem| Self::scalar_linear_map(&elem, key))
+            .iter()
+            .map(|elem| Self::scalar_linear_map(elem, key))
             .collect::<Vec<Self>>()
     }
 

--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -145,18 +145,9 @@ pub struct ComT<E: Pairing>(
 /// Collapse matrix into a single vector.
 pub fn col_vec_to_vec<F: Clone>(mat: &Matrix<F>) -> Vec<F> {
     if mat.len() == 1 {
-        let mut res = Vec::with_capacity(mat[0].len());
-        for elem in mat[0].iter() {
-            res.push(elem.clone());
-        }
-        res
+        mat[0].clone()
     } else {
-        let mut res = Vec::with_capacity(mat.len());
-        for i in 0..mat.len() {
-            assert_eq!(mat[i].len(), 1);
-            res.push(mat[i][0].clone());
-        }
-        res
+        mat.iter().map(|v| v[0].clone()).collect()
     }
 }
 
@@ -1653,6 +1644,13 @@ mod tests {
             };
         }
 
+        macro_rules! assert_matrix_dimensions {
+            ($matrix:ident, $rows:expr, $cols:expr) => {
+                assert_eq!($matrix.len(), $rows);
+                $matrix.iter().for_each(|r| assert_eq!(r.len(), $cols));
+            };
+        }
+
         #[test]
         fn test_col_vec_to_vec() {
             let mat = vec![
@@ -1704,8 +1702,7 @@ mod tests {
             let res: Matrix<Fr> = rhs.left_mul(&lhs, false);
 
             // 1 x 1 resulting matrix
-            assert_eq!(res.len(), 1);
-            assert_eq!(res[0].len(), 1);
+            assert_matrix_dimensions!(res, 1, 1);
 
             assert_eq!(exp, res);
         }
@@ -1729,8 +1726,7 @@ mod tests {
             let res: Matrix<Fr> = lhs.right_mul(&rhs, false);
 
             // 1 x 1 resulting matrix
-            assert_eq!(res.len(), 1);
-            assert_eq!(res[0].len(), 1);
+            assert_matrix_dimensions!(res, 1, 1);
 
             assert_eq!(exp, res);
         }
@@ -1785,9 +1781,7 @@ mod tests {
             let res: Matrix<Fr> = rhs.left_mul(&lhs, false);
 
             // 2 x 4 resulting matrix
-            assert_eq!(res.len(), 2);
-            assert_eq!(res[0].len(), 4);
-            assert_eq!(res[1].len(), 4);
+            assert_matrix_dimensions!(res, 2, 4);
 
             assert_eq!(exp, res);
         }
@@ -1956,9 +1950,7 @@ mod tests {
             let res: Matrix<Fr> = lhs.right_mul(&rhs, true);
 
             // 2 x 4 resulting matrix
-            assert_eq!(res.len(), 2);
-            assert_eq!(res[0].len(), 4);
-            assert_eq!(res[1].len(), 4);
+            assert_matrix_dimensions!(res, 2, 4);
 
             assert_eq!(exp, res);
         }
@@ -1989,8 +1981,7 @@ mod tests {
             let res: Matrix<Com1<F>> = rhs.left_mul(&lhs, false);
 
             // 1 x 1 resulting matrix
-            assert_eq!(res.len(), 1);
-            assert_eq!(res[0].len(), 1);
+            assert_matrix_dimensions!(res, 1, 1);
 
             assert_eq!(exp, res);
         }
@@ -2018,9 +2009,7 @@ mod tests {
             )]];
             let res: Matrix<Com1<F>> = lhs.right_mul(&rhs, false);
 
-            // 1 x 1 resulting matrix
-            assert_eq!(res.len(), 1);
-            assert_eq!(res[0].len(), 1);
+            assert_matrix_dimensions!(res, 1, 1);
 
             assert_eq!(exp, res);
         }
@@ -2142,10 +2131,7 @@ mod tests {
             ];
             let res: Matrix<Com1<F>> = mat.transpose();
 
-            assert_eq!(res.len(), 3);
-            for i in 0..res.len() {
-                assert_eq!(res[i].len(), 1);
-            }
+            assert_matrix_dimensions!(res, 3, 1);
             assert_eq!(exp, res);
         }
 
@@ -2191,10 +2177,7 @@ mod tests {
             ];
             let res: Matrix<Com1<F>> = mat.transpose();
 
-            assert_eq!(res.len(), 3);
-            for i in 0..res.len() {
-                assert_eq!(res[i].len(), 3);
-            }
+            assert_matrix_dimensions!(res, 3, 3);
 
             assert_eq!(exp, res);
         }
@@ -2217,10 +2200,7 @@ mod tests {
             ];
             let res: Matrix<Com2<F>> = mat.transpose();
 
-            assert_eq!(res.len(), 3);
-            for i in 0..res.len() {
-                assert_eq!(res[i].len(), 1);
-            }
+            assert_matrix_dimensions!(res, 3, 1);
             assert_eq!(exp, res);
         }
 
@@ -2266,10 +2246,7 @@ mod tests {
             ];
             let res: Matrix<Com2<F>> = mat.transpose();
 
-            assert_eq!(res.len(), 3);
-            for i in 0..res.len() {
-                assert_eq!(res[i].len(), 3);
-            }
+            assert_matrix_dimensions!(res, 3, 3);
 
             assert_eq!(exp, res);
         }
@@ -2292,10 +2269,7 @@ mod tests {
             ];
             let res: Matrix<Fr> = mat.transpose();
 
-            assert_eq!(res.len(), 3);
-            for i in 0..res.len() {
-                assert_eq!(res[i].len(), 1);
-            }
+            assert_matrix_dimensions!(res, 3, 1);
 
             assert_eq!(exp, res);
         }
@@ -2333,10 +2307,7 @@ mod tests {
             ];
             let res: Matrix<Fr> = mat.transpose();
 
-            assert_eq!(res.len(), 3);
-            for i in 0..res.len() {
-                assert_eq!(res[i].len(), 3);
-            }
+            assert_matrix_dimensions!(res, 3, 3);
 
             assert_eq!(exp, res);
         }
@@ -2378,10 +2349,7 @@ mod tests {
             ];
             let res: Matrix<Fr> = mat.neg();
 
-            assert_eq!(res.len(), 3);
-            for i in 0..res.len() {
-                assert_eq!(res[i].len(), 3);
-            }
+            assert_matrix_dimensions!(res, 3, 3);
 
             assert_eq!(exp, res);
         }
@@ -2428,10 +2396,7 @@ mod tests {
             ];
             let res: Matrix<Com1<F>> = mat.neg();
 
-            assert_eq!(res.len(), 3);
-            for i in 0..res.len() {
-                assert_eq!(res[i].len(), 3);
-            }
+            assert_matrix_dimensions!(res, 3, 3);
 
             assert_eq!(exp, res);
         }
@@ -2478,10 +2443,7 @@ mod tests {
             ];
             let res: Matrix<Com2<F>> = mat.neg();
 
-            assert_eq!(res.len(), 3);
-            for i in 0..res.len() {
-                assert_eq!(res[i].len(), 3);
-            }
+            assert_matrix_dimensions!(res, 3, 3);
 
             assert_eq!(exp, res);
         }
@@ -2540,10 +2502,7 @@ mod tests {
             let lr: Matrix<Fr> = lhs.add(&rhs);
             let rl: Matrix<Fr> = rhs.add(&lhs);
 
-            assert_eq!(lr.len(), 3);
-            for i in 0..lr.len() {
-                assert_eq!(lr[i].len(), 3);
-            }
+            assert_matrix_dimensions!(lr, 3, 3);
 
             assert_eq!(exp, lr);
             assert_eq!(lr, rl);
@@ -2609,10 +2568,7 @@ mod tests {
             let lr: Matrix<Com1<F>> = lhs.add(&rhs);
             let rl: Matrix<Com1<F>> = rhs.add(&lhs);
 
-            assert_eq!(lr.len(), 3);
-            for i in 0..lr.len() {
-                assert_eq!(lr[i].len(), 3);
-            }
+            assert_matrix_dimensions!(lr, 3, 3);
 
             assert_eq!(exp, lr);
             assert_eq!(lr, rl);
@@ -2678,10 +2634,7 @@ mod tests {
             let lr: Matrix<Com2<F>> = lhs.add(&rhs);
             let rl: Matrix<Com2<F>> = rhs.add(&lhs);
 
-            assert_eq!(lr.len(), 3);
-            for i in 0..lr.len() {
-                assert_eq!(lr[i].len(), 3);
-            }
+            assert_matrix_dimensions!(lr, 3, 3);
 
             assert_eq!(exp, lr);
             assert_eq!(lr, rl);

--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -662,10 +662,10 @@ macro_rules! impl_base_commit_mats {
                 }
 
                 fn right_mul(&self, rhs: &Matrix<Self::Other>, is_parallel: bool) -> Self {
-                    if self.len() == 0 || self[0].len() == 0 {
+                    if self.is_empty() || self[0].is_empty() {
                         return vec![];
                     }
-                    if rhs.len() == 0 || rhs[0].len() == 0 {
+                    if rhs.is_empty() || rhs[0].is_empty() {
                         return vec![];
                     }
 
@@ -729,10 +729,10 @@ macro_rules! impl_base_commit_mats {
                 }
 
                 fn left_mul(&self, lhs: &Matrix<Self::Other>, is_parallel: bool) -> Self {
-                    if lhs.len() == 0 || lhs[0].len() == 0 {
+                    if lhs.is_empty() || lhs[0].is_empty() {
                         return vec![];
                     }
-                    if self.len() == 0 || self[0].len() == 0 {
+                    if self.is_empty() || self[0].is_empty() {
                         return vec![];
                     }
 
@@ -871,10 +871,10 @@ impl<F: Field> Mat<F> for Matrix<F> {
     }
 
     fn right_mul(&self, rhs: &Matrix<Self::Other>, is_parallel: bool) -> Self {
-        if self.len() == 0 || self[0].len() == 0 {
+        if self.is_empty() || self[0].is_empty() {
             return vec![];
         }
-        if rhs.len() == 0 || rhs[0].len() == 0 {
+        if rhs.is_empty() || rhs[0].is_empty() {
             return vec![];
         }
 
@@ -928,10 +928,10 @@ impl<F: Field> Mat<F> for Matrix<F> {
     }
 
     fn left_mul(&self, lhs: &Matrix<Self::Other>, is_parallel: bool) -> Self {
-        if lhs.len() == 0 || lhs[0].len() == 0 {
+        if lhs.is_empty() || lhs[0].is_empty() {
             return vec![];
         }
-        if self.len() == 0 || self[0].len() == 0 {
+        if self.is_empty() || self[0].is_empty() {
             return vec![];
         }
 

--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -7,8 +7,8 @@
 //! In a Type-III pairing setting, the Groth-Sahai instantiation requires the SXDH assumption,
 //! implementing the commitment group using elements of the bilinear group over an elliptic curve.
 //! [`Com1`](crate::data_structures::Com1) and [`Com2`](crate::data_structures::Com2) are represented by 2 x 1 vectors of elements
-//! in the corresponding groups [`G1Affine`](ark_ec::PairingEngine::G1Affine) and [`G2Affine`](ark_ec::PairingEngine::G2Affine).
-//! [`ComT`](crate::data_structures::ComT) represents a 2 x 2 matrix of elements in [`Fqk`](ark_ec::PairingEngine::Fqk) (aka `GT`).
+//! in the corresponding groups [`G1Affine`](ark_ec::Pairing::G1Affine) and [`G2Affine`](ark_ec::Pairing::G2Affine).
+//! [`ComT`](crate::data_structures::ComT) represents a 2 x 2 matrix of elements in [`Fqk`](ark_ec::Pairing::Fqk) (aka `GT`).
 //!
 //! All of `Com1`, `Com2`, `ComT` are expressed as follows:
 //! * Addition in `Com1`, `Com2` is defined by entry-wise addition of elements in `G1Affine`, `G2Affine`:
@@ -24,23 +24,18 @@
 //! The Groth-Sahai proof system uses matrices of commitment group elements in its computations as
 //! well.
 
-use ark_ec::{PairingEngine, AffineCurve, ProjectiveCurve};
-#[allow(unused_imports)]
-use ark_ff::{Zero, One, Field, field_new};
+use ark_ec::{pairing::Pairing, AffineRepr, CurveGroup};
+use ark_ff::{Field, One, Zero};
 use ark_std::{
     fmt::Debug,
+    iter::Sum,
     ops::{Add, AddAssign, Neg, Sub, SubAssign},
-    iter::Sum
 };
 use rayon::prelude::*;
 
 use crate::generator::*;
 
-pub trait Mat<Elem: Clone>:
-    Eq
-    + Clone
-    + Debug
-{
+pub trait Mat<Elem: Clone>: Eq + Clone + Debug {
     type Other;
 
     fn add(&self, other: &Self) -> Self;
@@ -54,7 +49,7 @@ pub trait Mat<Elem: Clone>:
 pub type Matrix<E> = Vec<Vec<E>>;
 
 /// Encapsulates arithmetic traits for Groth-Sahai's bilinear group for commitments.
-pub trait B<E: PairingEngine>:
+pub trait B<E: Pairing>:
     Eq
     + Copy
     + Clone
@@ -66,12 +61,13 @@ pub trait B<E: PairingEngine>:
     + SubAssign<Self>
     + Neg<Output = Self>
     + Sum
-{}
+{
+}
 
 /// Provides linear maps and vector conversions for the base of the GS commitment group.
-pub trait B1<E: PairingEngine>:
+pub trait B1<E: Pairing>:
     B<E>
-//    + MulAssign<E::Fr>
+//    + MulAssign<E::ScalarField>
     + From<Matrix<E::G1Affine>>
 {
     fn as_col_vec(&self) -> Matrix<E::G1Affine>;
@@ -80,16 +76,16 @@ pub trait B1<E: PairingEngine>:
     fn linear_map(x: &E::G1Affine) -> Self;
     fn batch_linear_map(x_vec: &Vec<E::G1Affine>) -> Vec<Self>;
     /// The linear map from scalar field to B1 for multi-scalar multiplication and quadratic equations.
-    fn scalar_linear_map(x: &E::Fr, key: &CRS<E>) -> Self;
-    fn batch_scalar_linear_map(x_vec: &Vec<E::Fr>, key: &CRS<E>) -> Vec<Self>;
+    fn scalar_linear_map(x: &E::ScalarField, key: &CRS<E>) -> Self;
+    fn batch_scalar_linear_map(x_vec: &Vec<E::ScalarField>, key: &CRS<E>) -> Vec<Self>;
 
-    fn scalar_mul(&self, other: &E::Fr) -> Self;
+    fn scalar_mul(&self, other: &E::ScalarField) -> Self;
 }
 
 /// Provides linear maps and vector conversions for the extension of the GS commitment group.
-pub trait B2<E: PairingEngine>:
+pub trait B2<E: Pairing>:
     B<E>
-//    + MulAssign<E::Fr>
+//    + MulAssign<E::ScalarField>
     + From<Matrix<E::G2Affine>>
 {
     fn as_col_vec(&self) -> Matrix<E::G2Affine>;
@@ -98,19 +94,16 @@ pub trait B2<E: PairingEngine>:
     fn linear_map(y: &E::G2Affine) -> Self;
     fn batch_linear_map(y_vec: &Vec<E::G2Affine>) -> Vec<Self>;
     /// The linear map from scalar field to B2 for multi-scalar multiplication and quadratic equations.
-    fn scalar_linear_map(y: &E::Fr, key: &CRS<E>) -> Self;
-    fn batch_scalar_linear_map(y_vec: &Vec<E::Fr>, key: &CRS<E>) -> Vec<Self>;
+    fn scalar_linear_map(y: &E::ScalarField, key: &CRS<E>) -> Self;
+    fn batch_scalar_linear_map(y_vec: &Vec<E::ScalarField>, key: &CRS<E>) -> Vec<Self>;
 
-    fn scalar_mul(&self, other: &E::Fr) -> Self;
+    fn scalar_mul(&self, other: &E::ScalarField) -> Self;
 }
 
 /// Provides linear maps and matrix conversions for the target of the GS commitment group, as well as the equipped pairing.
-pub trait BT<E: PairingEngine, C1: B1<E>, C2: B2<E>>:
-    B<E>    
-    + From<Matrix<E::Fqk>>
-{
-    fn as_matrix(&self) -> Matrix<E::Fqk>;
-    
+pub trait BT<E: Pairing, C1: B1<E>, C2: B2<E>>: B<E> + From<Matrix<E::TargetField>> {
+    fn as_matrix(&self) -> Matrix<E::TargetField>;
+
     /// The bilinear pairing over the GS commitment group (B1, B2, BT) is the tensor product.
     /// with respect to the bilinear pairing over the bilinear group (G1, G2, GT).
     fn pairing(x: C1, y: C2) -> Self;
@@ -119,7 +112,7 @@ pub trait BT<E: PairingEngine, C1: B1<E>, C2: B2<E>>:
 
     /// The linear map from GT to BT for pairing-product equations.
     #[allow(non_snake_case)]
-    fn linear_map_PPE(z: &E::Fqk) -> Self;
+    fn linear_map_PPE(z: &E::TargetField) -> Self;
     /// The linear map from G1 to BT for multi-scalar multiplication equations.
     #[allow(non_snake_case)]
     fn linear_map_MSMEG1(z: &E::G1Affine, key: &CRS<E>) -> Self;
@@ -127,34 +120,37 @@ pub trait BT<E: PairingEngine, C1: B1<E>, C2: B2<E>>:
     #[allow(non_snake_case)]
     fn linear_map_MSMEG2(z: &E::G2Affine, key: &CRS<E>) -> Self;
     /// The linear map from Fr to BT for quadratic equations.
-    fn linear_map_quad(z: &E::Fr, key: &CRS<E>) -> Self;
+    fn linear_map_quad(z: &E::ScalarField, key: &CRS<E>) -> Self;
 }
 
 // SXDH instantiation's bilinear group for commitments
 
 /// Base [`B1`](crate::data_structures::B1) for the commitment group in the SXDH instantiation.
 #[derive(Copy, Clone, Debug)]
-pub struct Com1<E: PairingEngine>(pub E::G1Affine, pub E::G1Affine);
+pub struct Com1<E: Pairing>(pub E::G1Affine, pub E::G1Affine);
 
 /// Extension [`B2`](crate::data_structures::B2) for the commitment group in the SXDH instantiation.
 #[derive(Copy, Clone, Debug)]
-pub struct Com2<E: PairingEngine>(pub E::G2Affine, pub E::G2Affine);
+pub struct Com2<E: Pairing>(pub E::G2Affine, pub E::G2Affine);
 
 /// Target [`BT`](crate::data_structures::BT) for the commitment group in the SXDH instantiation.
 #[derive(Copy, Clone, Debug)]
-pub struct ComT<E: PairingEngine>(pub E::Fqk, pub E::Fqk, pub E::Fqk, pub E::Fqk);
+pub struct ComT<E: Pairing>(
+    pub E::TargetField,
+    pub E::TargetField,
+    pub E::TargetField,
+    pub E::TargetField,
+);
 
 /// Collapse matrix into a single vector.
 pub fn col_vec_to_vec<F: Clone>(mat: &Matrix<F>) -> Vec<F> {
-
     if mat.len() == 1 {
         let mut res = Vec::with_capacity(mat[0].len());
         for elem in mat[0].iter() {
             res.push(elem.clone());
         }
         res
-    }
-    else {
+    } else {
         let mut res = Vec::with_capacity(mat.len());
         for i in 0..mat.len() {
             assert_eq!(mat[i].len(), 1);
@@ -166,7 +162,6 @@ pub fn col_vec_to_vec<F: Clone>(mat: &Matrix<F>) -> Vec<F> {
 
 /// Expand vector into column vector (in matrix form).
 pub fn vec_to_col_vec<F: Clone>(vec: &Vec<F>) -> Matrix<F> {
-
     let mut mat = Vec::with_capacity(vec.len());
     for elem in vec.iter() {
         mat.push(vec![elem.clone()]);
@@ -183,76 +178,70 @@ macro_rules! impl_base_commit_groups {
         // Repeat for each $com
         $(
             // Equality for Com group
-            impl<E: PairingEngine> PartialEq for $com<E> {
+            impl<E: Pairing> PartialEq for $com<E> {
 
                 #[inline]
                 fn eq(&self, other: &Self) -> bool {
                     self.0 == other.0 && self.1 == other.1
                 }
             }
-            impl<E: PairingEngine> Eq for $com<E> {}
+            impl<E: Pairing> Eq for $com<E> {}
 
             // Addition for Com group
-            impl<E: PairingEngine> Add<$com<E>> for $com<E> {
+            impl<E: Pairing> Add<$com<E>> for $com<E> {
                 type Output = Self;
 
                 #[inline]
                 fn add(self, other: Self) -> Self {
                     Self (
-                        self.0 + other.0,
-                        self.1 + other.1
+                        (self.0 + other.0).into(),
+                        (self.1 + other.1).into()
                     )
                 }
             }
-            impl<E: PairingEngine> AddAssign<$com<E>> for $com<E> {
+            impl<E: Pairing> AddAssign<$com<E>> for $com<E> {
 
                 #[inline]
                 fn add_assign(&mut self, other: Self) {
                     *self = Self (
-                        self.0 + other.0,
-                        self.1 + other.1
+                        (self.0 + other.0).into(),
+                        (self.1 + other.1).into()
                     );
                 }
             }
-            impl<E: PairingEngine> Neg for $com<E> {
+            impl<E: Pairing> Neg for $com<E> {
                 type Output = Self;
 
                 #[inline]
                 fn neg(self) -> Self::Output {
                     Self (
-                        -self.0,
-                        -self.1
+                        (-(self.0.into_group())).into(),
+                        (-(self.1.into_group())).into()
                     )
                 }
             }
-            impl<E: PairingEngine> Sub<$com<E>> for $com<E> {
+            impl<E: Pairing> Sub<$com<E>> for $com<E> {
                 type Output = Self;
 
                 #[inline]
                 fn sub(self, other: Self) -> Self {
-                    Self (
-                        self.0 + -other.0,
-                        self.1 + -other.1
-                    )
+                    self + -other
                 }
             }
-            impl<E: PairingEngine> SubAssign<$com<E>> for $com<E> {
+            impl<E: Pairing> SubAssign<$com<E>> for $com<E> {
 
                 #[inline]
                 fn sub_assign(&mut self, other: Self) {
-                    *self = Self (
-                        self.0 + -other.0,
-                        self.1 + -other.1
-                    );
+                    *self += -other;
                 }
             }
             /*
             // Entry-wise scalar point-multiplication
-            impl <E: PairingEngine> MulAssign<E::Fr> for $com<E> {
-                fn mul_assign(&mut self, rhs: E::Fr) {
-                    
+            impl <E: Pairing> MulAssign<E::ScalarField> for $com<E> {
+                fn mul_assign(&mut self, rhs: E::ScalarField) {
+
                     let mut s1p = self.0.into_projective();
-                    let mut s2p = self.1.into_projective();  
+                    let mut s2p = self.1.into_projective();
                     s1p *= rhs;
                     s2p *= rhs;
                     *self = Self (
@@ -262,7 +251,7 @@ macro_rules! impl_base_commit_groups {
                 }
             }
             */
-            impl<E: PairingEngine> Sum for $com<E> {
+            impl<E: Pairing> Sum for $com<E> {
                 fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {
                     iter.fold(
                         Self::zero(),
@@ -275,13 +264,10 @@ macro_rules! impl_base_commit_groups {
 }
 impl_base_commit_groups!(Com1, Com2);
 
-impl<E: PairingEngine> Zero for Com1<E> {
+impl<E: Pairing> Zero for Com1<E> {
     #[inline]
     fn zero() -> Self {
-        Self (
-            E::G1Affine::zero(),
-            E::G1Affine::zero()
-        )
+        Self(E::G1Affine::zero(), E::G1Affine::zero())
     }
 
     #[inline]
@@ -289,13 +275,10 @@ impl<E: PairingEngine> Zero for Com1<E> {
         *self == Self::zero()
     }
 }
-impl<E: PairingEngine> Zero for Com2<E> {
+impl<E: Pairing> Zero for Com2<E> {
     #[inline]
     fn zero() -> Self {
-        Self (
-            E::G2Affine::zero(),
-            E::G2Affine::zero()
-        )
+        Self(E::G2Affine::zero(), E::G2Affine::zero())
     }
 
     #[inline]
@@ -304,151 +287,131 @@ impl<E: PairingEngine> Zero for Com2<E> {
     }
 }
 
-impl<E: PairingEngine> B<E> for Com1<E> {}
-impl<E: PairingEngine> B<E> for Com2<E> {}
+impl<E: Pairing> B<E> for Com1<E> {}
+impl<E: Pairing> B<E> for Com2<E> {}
 
-impl<E: PairingEngine> From<Matrix<E::G1Affine>> for Com1<E> {
+impl<E: Pairing> From<Matrix<E::G1Affine>> for Com1<E> {
     fn from(mat: Matrix<E::G1Affine>) -> Self {
         assert_eq!(mat.len(), 2);
         assert_eq!(mat[0].len(), 1);
         assert_eq!(mat[1].len(), 1);
-        Self (
-            mat[0][0],
-            mat[1][0]
-        )
+        Self(mat[0][0], mat[1][0])
     }
 }
-impl<E: PairingEngine> From<Matrix<E::G2Affine>> for Com2<E> {
+impl<E: Pairing> From<Matrix<E::G2Affine>> for Com2<E> {
     fn from(mat: Matrix<E::G2Affine>) -> Self {
         assert_eq!(mat.len(), 2);
         assert_eq!(mat[0].len(), 1);
         assert_eq!(mat[1].len(), 1);
-        Self (
-            mat[0][0],
-            mat[1][0]
-        )
+        Self(mat[0][0], mat[1][0])
     }
 }
 
-impl<E: PairingEngine> B1<E> for Com1<E> {
+impl<E: Pairing> B1<E> for Com1<E> {
     fn as_col_vec(&self) -> Matrix<E::G1Affine> {
-        vec![ vec![self.0], vec![self.1] ]
+        vec![vec![self.0], vec![self.1]]
     }
 
     fn as_vec(&self) -> Vec<E::G1Affine> {
-        vec![ self.0, self.1 ]
+        vec![self.0, self.1]
     }
 
     #[inline]
     fn linear_map(x: &E::G1Affine) -> Self {
-        Self (
-            E::G1Affine::zero(),
-            x.clone()
-        )
+        Self(E::G1Affine::zero(), x.clone())
     }
 
     #[inline]
     fn batch_linear_map(x_vec: &Vec<E::G1Affine>) -> Vec<Self> {
         x_vec
             .into_iter()
-            .map( |elem| Self::linear_map(&elem))
+            .map(|elem| Self::linear_map(&elem))
             .collect::<Vec<Self>>()
     }
 
     #[inline]
-    fn scalar_linear_map(x: &E::Fr, key: &CRS<E>) -> Self {
+    fn scalar_linear_map(x: &E::ScalarField, key: &CRS<E>) -> Self {
         // = xu, where u = u_2 + (O, P) is a commitment group element
-        ( key.u[1] + Com1::<E>::linear_map(&key.g1_gen) ).scalar_mul(&x)
+        (key.u[1] + Com1::<E>::linear_map(&key.g1_gen)).scalar_mul(&x)
     }
 
     #[inline]
-    fn batch_scalar_linear_map(x_vec: &Vec<E::Fr>, key: &CRS<E>) -> Vec<Self> {
+    fn batch_scalar_linear_map(x_vec: &Vec<E::ScalarField>, key: &CRS<E>) -> Vec<Self> {
         x_vec
             .into_iter()
-            .map( |elem| Self::scalar_linear_map(&elem, key))
+            .map(|elem| Self::scalar_linear_map(&elem, key))
             .collect::<Vec<Self>>()
     }
 
-    fn scalar_mul(&self, rhs: &E::Fr) -> Self {
-
-        let mut s1p = self.0.clone().into_projective();
-        let mut s2p = self.1.clone().into_projective();
+    fn scalar_mul(&self, rhs: &E::ScalarField) -> Self {
+        let mut s1p = self.0.clone().into_group();
+        let mut s2p = self.1.clone().into_group();
         s1p *= *rhs;
         s2p *= *rhs;
-        Self (
-            s1p.into_affine().clone(),
-            s2p.into_affine().clone()
-        )
+        Self(s1p.into_affine().clone(), s2p.into_affine().clone())
     }
 }
 
-impl<E: PairingEngine> B2<E> for Com2<E> {
+impl<E: Pairing> B2<E> for Com2<E> {
     fn as_col_vec(&self) -> Matrix<E::G2Affine> {
-        vec![ vec![self.0], vec![self.1] ]
+        vec![vec![self.0], vec![self.1]]
     }
 
     fn as_vec(&self) -> Vec<E::G2Affine> {
-        vec![ self.0, self.1 ]
+        vec![self.0, self.1]
     }
 
     #[inline]
     fn linear_map(y: &E::G2Affine) -> Self {
-        Self (
-            E::G2Affine::zero(),
-            y.clone()
-        )
+        Self(E::G2Affine::zero(), y.clone())
     }
 
     #[inline]
     fn batch_linear_map(y_vec: &Vec<E::G2Affine>) -> Vec<Self> {
         y_vec
             .into_iter()
-            .map( |elem| Self::linear_map(&elem))
+            .map(|elem| Self::linear_map(&elem))
             .collect::<Vec<Self>>()
     }
 
     #[inline]
-    fn scalar_linear_map(y: &E::Fr, key: &CRS<E>) -> Self {
+    fn scalar_linear_map(y: &E::ScalarField, key: &CRS<E>) -> Self {
         // = yv, where v = v_2 + (O, P) is a commitment group element
-        ( key.v[1] + Com2::<E>::linear_map(&key.g2_gen) ).scalar_mul(&y)
+        (key.v[1] + Com2::<E>::linear_map(&key.g2_gen)).scalar_mul(&y)
     }
 
     #[inline]
-    fn batch_scalar_linear_map(y_vec: &Vec<E::Fr>, key: &CRS<E>) -> Vec<Self> {
+    fn batch_scalar_linear_map(y_vec: &Vec<E::ScalarField>, key: &CRS<E>) -> Vec<Self> {
         y_vec
             .into_iter()
-            .map( |elem| Self::scalar_linear_map(&elem, key))
+            .map(|elem| Self::scalar_linear_map(&elem, key))
             .collect::<Vec<Self>>()
     }
 
-    fn scalar_mul(&self, rhs: &E::Fr) -> Self{
-
-        let mut s1p = self.0.clone().into_projective();
-        let mut s2p = self.1.clone().into_projective();
+    fn scalar_mul(&self, rhs: &E::ScalarField) -> Self {
+        let mut s1p = self.0.clone().into_group();
+        let mut s2p = self.1.clone().into_group();
         s1p *= *rhs;
         s2p *= *rhs;
-        Self (
-            s1p.into_affine().clone(),
-            s2p.into_affine().clone()
-        )
+        Self(s1p.into_affine().clone(), s2p.into_affine().clone())
     }
 }
 
 // ComT<Com1, Com2> is an instantiation of BT<B1, B2>
-impl<E: PairingEngine> PartialEq for ComT<E> {
+impl<E: Pairing> PartialEq for ComT<E> {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.0 == other.0 && self.1 == other.1 && self.2 == other.2 && self.3 == other.3
     }
 }
-impl<E: PairingEngine> Eq for ComT<E> {}
+impl<E: Pairing> Eq for ComT<E> {}
 
-impl<E: PairingEngine> Add<ComT<E>> for ComT<E> {
+impl<E: Pairing> Add<ComT<E>> for ComT<E> {
     type Output = Self;
 
     #[inline]
     fn add(self, other: Self) -> Self {
-        Self (
+        Self(
             self.0 * other.0,
             self.1 * other.1,
             self.2 * other.2,
@@ -456,14 +419,14 @@ impl<E: PairingEngine> Add<ComT<E>> for ComT<E> {
         )
     }
 }
-impl<E: PairingEngine> Zero for ComT<E> {
+impl<E: Pairing> Zero for ComT<E> {
     #[inline]
     fn zero() -> Self {
-        Self (
-            E::Fqk::one(),
-            E::Fqk::one(),
-            E::Fqk::one(),
-            E::Fqk::one()
+        Self(
+            E::TargetField::one(),
+            E::TargetField::one(),
+            E::TargetField::one(),
+            E::TargetField::one(),
         )
     }
 
@@ -472,131 +435,127 @@ impl<E: PairingEngine> Zero for ComT<E> {
         *self == Self::zero()
     }
 }
-impl<E: PairingEngine> AddAssign<ComT<E>> for ComT<E> {
-
+impl<E: Pairing> AddAssign<ComT<E>> for ComT<E> {
     #[inline]
     fn add_assign(&mut self, other: Self) {
-        *self = Self (
+        *self = Self(
             self.0 * other.0,
             self.1 * other.1,
             self.2 * other.2,
-            self.3 * other.3
+            self.3 * other.3,
         );
     }
 }
-impl<E: PairingEngine> Neg for ComT<E> {
+impl<E: Pairing> Neg for ComT<E> {
     type Output = Self;
 
     #[inline]
     fn neg(self) -> Self::Output {
-        Self (
-            E::Fqk::one() / self.0,
-            E::Fqk::one() / self.1,
-            E::Fqk::one() / self.2,
-            E::Fqk::one() / self.3
+        Self(
+            E::TargetField::one() / self.0,
+            E::TargetField::one() / self.1,
+            E::TargetField::one() / self.2,
+            E::TargetField::one() / self.3,
         )
     }
 }
-impl<E: PairingEngine> Sub<ComT<E>> for ComT<E> {
+impl<E: Pairing> Sub<ComT<E>> for ComT<E> {
     type Output = Self;
 
     #[inline]
     fn sub(self, other: Self) -> Self {
-        Self (
+        Self(
             self.0 / other.0,
             self.1 / other.1,
             self.2 / other.2,
-            self.3 / other.3
+            self.3 / other.3,
         )
     }
 }
-impl<E: PairingEngine> SubAssign<ComT<E>> for ComT<E> {
-
+impl<E: Pairing> SubAssign<ComT<E>> for ComT<E> {
     #[inline]
     fn sub_assign(&mut self, other: Self) {
-        *self = Self (
+        *self = Self(
             self.0 / other.0,
             self.1 / other.1,
             self.2 / other.2,
-            self.3 / other.3
+            self.3 / other.3,
         );
     }
 }
-impl<E: PairingEngine> From<Matrix<E::Fqk>> for ComT<E> {
-    fn from(mat: Matrix<E::Fqk>) -> Self {
+impl<E: Pairing> From<Matrix<E::TargetField>> for ComT<E> {
+    fn from(mat: Matrix<E::TargetField>) -> Self {
         assert_eq!(mat.len(), 2);
         assert_eq!(mat[0].len(), 2);
         assert_eq!(mat[1].len(), 2);
-        Self (
-            mat[0][0],
-            mat[0][1],
-            mat[1][0],
-            mat[1][1]
-        )
+        Self(mat[0][0], mat[0][1], mat[1][0], mat[1][1])
     }
 }
-impl<E: PairingEngine> Sum for ComT<E> {
-    fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {
-        iter.fold(
-            Self::zero(),
-            |a,b| a + b,
-        )
+impl<E: Pairing> Sum for ComT<E> {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Self::zero(), |a, b| a + b)
     }
 }
 
-impl<E: PairingEngine> B<E> for ComT<E> {}
-impl<E: PairingEngine> BT<E, Com1<E>, Com2<E>> for ComT<E> {
+impl<E: Pairing> B<E> for ComT<E> {}
+impl<E: Pairing> BT<E, Com1<E>, Com2<E>> for ComT<E> {
     #[inline]
     fn pairing(x: Com1<E>, y: Com2<E>) -> ComT<E> {
         ComT::<E>(
-            E::pairing::<E::G1Affine, E::G2Affine>(x.0.clone(), y.0.clone()),
-            E::pairing::<E::G1Affine, E::G2Affine>(x.0.clone(), y.1.clone()),
-            E::pairing::<E::G1Affine, E::G2Affine>(x.1.clone(), y.0.clone()),
-            E::pairing::<E::G1Affine, E::G2Affine>(x.1.clone(), y.1.clone()),
+            E::pairing(x.0.clone(), y.0.clone()).0,
+            E::pairing(x.0.clone(), y.1.clone()).0,
+            E::pairing(x.1.clone(), y.0.clone()).0,
+            E::pairing(x.1.clone(), y.1.clone()).0,
         )
     }
 
     #[inline]
     fn pairing_sum(x_vec: &Vec<Com1<E>>, y_vec: &Vec<Com2<E>>) -> ComT<E> {
-
         assert_eq!(x_vec.len(), y_vec.len());
-        let xy_vec = x_vec.into_iter().zip(y_vec).collect::<Vec<(&Com1<E>, &Com2<E>)>>();
+        let xy_vec = x_vec
+            .into_iter()
+            .zip(y_vec)
+            .collect::<Vec<(&Com1<E>, &Com2<E>)>>();
 
-        xy_vec.into_iter().map(|(&x, &y)| {
-            Self::pairing(x, y)
-        }).sum()
+        xy_vec.into_iter().map(|(&x, &y)| Self::pairing(x, y)).sum()
     }
 
-    fn as_matrix(&self) -> Matrix<E::Fqk> {
-        vec![
-            vec![ self.0, self.1 ],
-            vec![ self.2, self.3 ]
-        ]
+    fn as_matrix(&self) -> Matrix<E::TargetField> {
+        vec![vec![self.0, self.1], vec![self.2, self.3]]
     }
 
     #[inline]
-    fn linear_map_PPE(z: &E::Fqk) -> Self {
-        Self (
-            E::Fqk::one(),
-            E::Fqk::one(),
-            E::Fqk::one(),
-            z.clone()
+    fn linear_map_PPE(z: &E::TargetField) -> Self {
+        Self(
+            E::TargetField::one(),
+            E::TargetField::one(),
+            E::TargetField::one(),
+            z.clone(),
         )
     }
 
     #[inline]
     fn linear_map_MSMEG1(z: &E::G1Affine, key: &CRS<E>) -> Self {
-        Self::pairing(Com1::<E>::linear_map(z), Com2::<E>::scalar_linear_map(&E::Fr::one(), key))
+        Self::pairing(
+            Com1::<E>::linear_map(z),
+            Com2::<E>::scalar_linear_map(&E::ScalarField::one(), key),
+        )
     }
 
     #[inline]
     fn linear_map_MSMEG2(z: &E::G2Affine, key: &CRS<E>) -> Self {
-        Self::pairing(Com1::<E>::scalar_linear_map(&E::Fr::one(), key), Com2::<E>::linear_map(z))
+        Self::pairing(
+            Com1::<E>::scalar_linear_map(&E::ScalarField::one(), key),
+            Com2::<E>::linear_map(z),
+        )
     }
 
     #[inline]
-    fn linear_map_quad(z: &E::Fr, key: &CRS<E>) -> Self {
-        Self::pairing(Com1::<E>::scalar_linear_map(&E::Fr::one(), key), Com2::<E>::scalar_linear_map(&E::Fr::one(), key).scalar_mul(z))
+    fn linear_map_quad(z: &E::ScalarField, key: &CRS<E>) -> Self {
+        Self::pairing(
+            Com1::<E>::scalar_linear_map(&E::ScalarField::one(), key),
+            Com2::<E>::scalar_linear_map(&E::ScalarField::one(), key).scalar_mul(z),
+        )
     }
 }
 
@@ -613,8 +572,8 @@ macro_rules! impl_base_commit_mats {
 
             /*
             // Implements scalar point-multiplication for matrices of commitment group elements
-            impl<E: PairingEngine> MulAssign<E::Fr> for Matrix<$com<E>> {
-                fn mul_assign(&mut self, other: E::Fr) {
+            impl<E: Pairing> MulAssign<E::ScalarField> for Matrix<$com<E>> {
+                fn mul_assign(&mut self, other: E::ScalarField) {
                     let m = self.len();
                     let n = self[0].len();
                     let mut smul = Vec::with_capacity(m);
@@ -629,7 +588,7 @@ macro_rules! impl_base_commit_mats {
                     *self = smul;
                 }
             }
-            impl<E: PairingEngine> Neg<Output = Self> for Matrix<$com<E>> {
+            impl<E: Pairing> Neg<Output = Self> for Matrix<$com<E>> {
 
                 #[inline]
                 fn neg(self) -> Self::Output {
@@ -644,8 +603,8 @@ macro_rules! impl_base_commit_mats {
                 }
             }
             */
-            impl<E: PairingEngine> Mat<$com<E>> for Matrix<$com<E>> {
-                type Other = E::Fr;
+            impl<E: Pairing> Mat<$com<E>> for Matrix<$com<E>> {
+                type Other = E::ScalarField;
 
                 fn add(&self, other: &Self) -> Self {
                     assert_eq!(self.len(), other.len());
@@ -875,14 +834,12 @@ impl<F: Field> Mat<F> for Matrix<F> {
 
     #[inline]
     fn neg(&self) -> Self {
-       (0..self.len()).map( |i| {
-           let row = &self[i];
-           (0..row.len()).map( |j| {
-               -row[j]
-           })
-           .collect::<Vec<F>>()
-       })
-       .collect::<Vec<Vec<F>>>()
+        (0..self.len())
+            .map(|i| {
+                let row = &self[i];
+                (0..row.len()).map(|j| -row[j]).collect::<Vec<F>>()
+            })
+            .collect::<Vec<Vec<F>>>()
     }
 
     fn scalar_mul(&self, other: &Self::Other) -> Self {
@@ -928,7 +885,7 @@ impl<F: Field> Mat<F> for Matrix<F> {
         if is_parallel {
             let mut rows = (0..row_dim)
                 .into_par_iter()
-                .map( |i| {
+                .map(|i| {
                     let row = &self[i];
                     let dim = rhs.len();
 
@@ -936,18 +893,14 @@ impl<F: Field> Mat<F> for Matrix<F> {
                     // Assuming every column in b has the same length
                     let mut cols = (0..rhs[0].len())
                         .into_par_iter()
-                        .map( |j| {
-                            (j, (0..dim).map( |k| row[k] * rhs[k][j] ).sum())
-                        })
+                        .map(|j| (j, (0..dim).map(|k| row[k] * rhs[k][j]).sum()))
                         .collect::<Vec<(usize, F)>>();
 
                     // After computing concurrently, sort by index
                     cols.par_sort_by(|left, right| left.0.cmp(&right.0));
 
                     // Strip off index and return Vec<F>
-                    let final_row = cols.into_iter()
-                        .map( |(_, elem)| elem)
-                        .collect();
+                    let final_row = cols.into_iter().map(|(_, elem)| elem).collect();
 
                     (i, final_row)
                 })
@@ -957,23 +910,17 @@ impl<F: Field> Mat<F> for Matrix<F> {
             rows.par_sort_by(|left, right| left.0.cmp(&right.0));
 
             // Strip off index and return Vec<Vec<F>> (i.e. Matrix<F>)
-            rows.into_iter()
-                .map( |(_, row)| row)
-                .collect()
-        }
-        else {
-
+            rows.into_iter().map(|(_, row)| row).collect()
+        } else {
             (0..row_dim)
-                .map( |i| {
+                .map(|i| {
                     let row = &self[i];
                     let dim = rhs.len();
 
                     // Perform matrix multiplication for single row
                     // Assuming every column in b has the same length
                     (0..rhs[0].len())
-                        .map( |j| {
-                            (0..dim).map( |k| row[k] * rhs[k][j] ).sum()
-                        })
+                        .map(|j| (0..dim).map(|k| row[k] * rhs[k][j]).sum())
                         .collect::<Vec<F>>()
                 })
                 .collect::<Vec<Vec<F>>>()
@@ -995,25 +942,21 @@ impl<F: Field> Mat<F> for Matrix<F> {
         if is_parallel {
             let mut rows = (0..row_dim)
                 .into_par_iter()
-                .map( |i| {
+                .map(|i| {
                     let row = &lhs[i];
                     let dim = self.len();
 
                     // Perform matrix multiplication for single row
                     let mut cols = (0..self[0].len())
                         .into_par_iter()
-                        .map( |j| {
-                            (j, (0..dim).map( |k| self[k][j] * row[k] ).sum())
-                        })
+                        .map(|j| (j, (0..dim).map(|k| self[k][j] * row[k]).sum()))
                         .collect::<Vec<(usize, F)>>();
 
                     // After computing concurrently, sort by index
                     cols.par_sort_by(|left, right| left.0.cmp(&right.0));
 
                     // Strip off index and return Vec<F>
-                    let final_row = cols.into_iter()
-                        .map( |(_, elem)| elem)
-                        .collect();
+                    let final_row = cols.into_iter().map(|(_, elem)| elem).collect();
 
                     (i, final_row)
                 })
@@ -1023,19 +966,14 @@ impl<F: Field> Mat<F> for Matrix<F> {
             rows.par_sort_by(|left, right| left.0.cmp(&right.0));
 
             // Strip off index and return Vec<Vec<F>> (i.e. Matrix<F>)
-            rows.into_iter()
-                .map( |(_, row)| row)
-                .collect()
-        }
-        else {
+            rows.into_iter().map(|(_, row)| row).collect()
+        } else {
             (0..row_dim)
-                .map( |i| {
+                .map(|i| {
                     let row = &lhs[i];
                     let dim = self.len();
                     (0..self[0].len())
-                        .map( |j| {
-                            (0..dim).map( |k| self[k][j] * row[k] ).sum()
-                        })
+                        .map(|j| (0..dim).map(|k| self[k][j] * row[k]).sum())
                         .collect::<Vec<F>>()
                 })
                 .collect::<Vec<Vec<F>>>()
@@ -1043,38 +981,35 @@ impl<F: Field> Mat<F> for Matrix<F> {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
 
     #![allow(non_snake_case)]
     mod SXDH_com_group {
 
-        use ark_bls12_381::{Bls12_381 as F};
+        use ark_bls12_381::Bls12_381 as F;
+        use ark_ec::{AffineRepr, CurveGroup};
         use ark_ff::UniformRand;
-        use ark_ec::ProjectiveCurve;
+        use ark_std::ops::Mul;
         use ark_std::test_rng;
 
         use crate::data_structures::*;
 
-        type G1Affine = <F as PairingEngine>::G1Affine;
-        type G1Projective = <F as PairingEngine>::G1Projective;
-        type G2Affine = <F as PairingEngine>::G2Affine;
-        type G2Projective = <F as PairingEngine>::G2Projective;
-        type Fqk = <F as PairingEngine>::Fqk;
-        type Fr = <F as PairingEngine>::Fr;
+        type G1Affine = <F as Pairing>::G1Affine;
+        type G1Projective = <F as Pairing>::G1;
+        type G2Affine = <F as Pairing>::G2Affine;
+        type G2Projective = <F as Pairing>::G2;
+        type Fqk = <F as Pairing>::TargetField;
+        type Fr = <F as Pairing>::ScalarField;
 
         #[test]
         fn test_B1_add_zero() {
             let mut rng = test_rng();
             let a = Com1::<F>(
                 G1Projective::rand(&mut rng).into_affine(),
-                G1Projective::rand(&mut rng).into_affine()
+                G1Projective::rand(&mut rng).into_affine(),
             );
-            let zero = Com1::<F>(
-                G1Affine::zero(),
-                G1Affine::zero()
-            );
+            let zero = Com1::<F>(G1Affine::zero(), G1Affine::zero());
             let asub = a + zero;
 
             assert_eq!(zero, Com1::<F>::zero());
@@ -1088,12 +1023,9 @@ mod tests {
             let mut rng = test_rng();
             let a = Com2::<F>(
                 G2Projective::rand(&mut rng).into_affine(),
-                G2Projective::rand(&mut rng).into_affine()
+                G2Projective::rand(&mut rng).into_affine(),
             );
-            let zero = Com2::<F>(
-                G2Affine::zero(),
-                G2Affine::zero()
-            );
+            let zero = Com2::<F>(G2Affine::zero(), G2Affine::zero());
             let asub = a + zero;
 
             assert_eq!(zero, Com2::<F>::zero());
@@ -1109,14 +1041,9 @@ mod tests {
                 Fqk::rand(&mut rng),
                 Fqk::rand(&mut rng),
                 Fqk::rand(&mut rng),
-                Fqk::rand(&mut rng)
+                Fqk::rand(&mut rng),
             );
-            let zero = ComT::<F>(
-                Fqk::one(),
-                Fqk::one(),
-                Fqk::one(),
-                Fqk::one()
-            );
+            let zero = ComT::<F>(Fqk::one(), Fqk::one(), Fqk::one(), Fqk::one());
             let asub = a + zero;
 
             assert_eq!(zero, ComT::<F>::zero());
@@ -1130,16 +1057,16 @@ mod tests {
             let mut rng = test_rng();
             let a = Com1::<F>(
                 G1Projective::rand(&mut rng).into_affine(),
-                G1Projective::rand(&mut rng).into_affine()
+                G1Projective::rand(&mut rng).into_affine(),
             );
             let b = Com1::<F>(
                 G1Projective::rand(&mut rng).into_affine(),
-                G1Projective::rand(&mut rng).into_affine()
+                G1Projective::rand(&mut rng).into_affine(),
             );
             let ab = a + b;
             let ba = b + a;
 
-            assert_eq!(ab, Com1::<F>(a.0 + b.0, a.1 + b.1));
+            assert_eq!(ab, Com1::<F>((a.0 + b.0).into(), (a.1 + b.1).into()));
             assert_eq!(ab, ba);
         }
 
@@ -1149,16 +1076,16 @@ mod tests {
             let mut rng = test_rng();
             let a = Com2::<F>(
                 G2Projective::rand(&mut rng).into_affine(),
-                G2Projective::rand(&mut rng).into_affine()
+                G2Projective::rand(&mut rng).into_affine(),
             );
             let b = Com2::<F>(
                 G2Projective::rand(&mut rng).into_affine(),
-                G2Projective::rand(&mut rng).into_affine()
+                G2Projective::rand(&mut rng).into_affine(),
             );
             let ab = a + b;
             let ba = b + a;
 
-            assert_eq!(ab, Com2::<F>(a.0 + b.0, a.1 + b.1));
+            assert_eq!(ab, Com2::<F>((a.0 + b.0).into(), (a.1 + b.1).into()));
             assert_eq!(ab, ba);
         }
 
@@ -1170,13 +1097,13 @@ mod tests {
                 Fqk::rand(&mut rng),
                 Fqk::rand(&mut rng),
                 Fqk::rand(&mut rng),
-                Fqk::rand(&mut rng)
+                Fqk::rand(&mut rng),
             );
             let b = ComT::<F>(
                 Fqk::rand(&mut rng),
                 Fqk::rand(&mut rng),
                 Fqk::rand(&mut rng),
-                Fqk::rand(&mut rng)
+                Fqk::rand(&mut rng),
             );
             let ab = a + b;
             let ba = b + a;
@@ -1185,22 +1112,21 @@ mod tests {
             assert_eq!(ab, ba);
         }
 
-
         #[allow(non_snake_case)]
         #[test]
         fn test_B1_sum() {
             let mut rng = test_rng();
             let a = Com1::<F>(
                 G1Projective::rand(&mut rng).into_affine(),
-                G1Projective::rand(&mut rng).into_affine()
+                G1Projective::rand(&mut rng).into_affine(),
             );
             let b = Com1::<F>(
                 G1Projective::rand(&mut rng).into_affine(),
-                G1Projective::rand(&mut rng).into_affine()
+                G1Projective::rand(&mut rng).into_affine(),
             );
             let c = Com1::<F>(
                 G1Projective::rand(&mut rng).into_affine(),
-                G1Projective::rand(&mut rng).into_affine()
+                G1Projective::rand(&mut rng).into_affine(),
             );
 
             let abc_vec = vec![a, b, c];
@@ -1215,15 +1141,15 @@ mod tests {
             let mut rng = test_rng();
             let a = Com2::<F>(
                 G2Projective::rand(&mut rng).into_affine(),
-                G2Projective::rand(&mut rng).into_affine()
+                G2Projective::rand(&mut rng).into_affine(),
             );
             let b = Com2::<F>(
                 G2Projective::rand(&mut rng).into_affine(),
-                G2Projective::rand(&mut rng).into_affine()
+                G2Projective::rand(&mut rng).into_affine(),
             );
             let c = Com2::<F>(
                 G2Projective::rand(&mut rng).into_affine(),
-                G2Projective::rand(&mut rng).into_affine()
+                G2Projective::rand(&mut rng).into_affine(),
             );
 
             let abc_vec = vec![a, b, c];
@@ -1240,19 +1166,19 @@ mod tests {
                 Fqk::rand(&mut rng),
                 Fqk::rand(&mut rng),
                 Fqk::rand(&mut rng),
-                Fqk::rand(&mut rng)
+                Fqk::rand(&mut rng),
             );
             let b = ComT::<F>(
                 Fqk::rand(&mut rng),
                 Fqk::rand(&mut rng),
                 Fqk::rand(&mut rng),
-                Fqk::rand(&mut rng)
+                Fqk::rand(&mut rng),
             );
             let c = ComT::<F>(
                 Fqk::rand(&mut rng),
                 Fqk::rand(&mut rng),
                 Fqk::rand(&mut rng),
-                Fqk::rand(&mut rng)
+                Fqk::rand(&mut rng),
             );
 
             let abc_vec = vec![a, b, c];
@@ -1267,7 +1193,7 @@ mod tests {
             let mut rng = test_rng();
             let b = Com1::<F>(
                 G1Projective::rand(&mut rng).into_affine(),
-                G1Projective::rand(&mut rng).into_affine()
+                G1Projective::rand(&mut rng).into_affine(),
             );
             let bneg = -b;
             let zero = b + bneg;
@@ -1281,7 +1207,7 @@ mod tests {
             let mut rng = test_rng();
             let b = Com2::<F>(
                 G2Projective::rand(&mut rng).into_affine(),
-                G2Projective::rand(&mut rng).into_affine()
+                G2Projective::rand(&mut rng).into_affine(),
             );
             let bneg = -b;
             let zero = b + bneg;
@@ -1311,16 +1237,16 @@ mod tests {
             let mut rng = test_rng();
             let a = Com1::<F>(
                 G1Projective::rand(&mut rng).into_affine(),
-                G1Projective::rand(&mut rng).into_affine()
+                G1Projective::rand(&mut rng).into_affine(),
             );
             let b = Com1::<F>(
                 G1Projective::rand(&mut rng).into_affine(),
-                G1Projective::rand(&mut rng).into_affine()
+                G1Projective::rand(&mut rng).into_affine(),
             );
             let ab = a - b;
             let ba = b - a;
 
-            assert_eq!(ab, Com1::<F>(a.0 + -b.0, a.1 + -b.1));
+            assert_eq!(ab, Com1::<F>((a.0 + -b.0).into(), (a.1 + -b.1).into()));
             assert_eq!(ab, -ba);
         }
 
@@ -1330,16 +1256,16 @@ mod tests {
             let mut rng = test_rng();
             let a = Com2::<F>(
                 G2Projective::rand(&mut rng).into_affine(),
-                G2Projective::rand(&mut rng).into_affine()
+                G2Projective::rand(&mut rng).into_affine(),
             );
             let b = Com2::<F>(
                 G2Projective::rand(&mut rng).into_affine(),
-                G2Projective::rand(&mut rng).into_affine()
+                G2Projective::rand(&mut rng).into_affine(),
             );
             let ab = a - b;
             let ba = b - a;
 
-            assert_eq!(ab, Com2::<F>(a.0 + -b.0, a.1 + -b.1));
+            assert_eq!(ab, Com2::<F>((a.0 + -b.0).into(), (a.1 + -b.1).into()));
             assert_eq!(ab, -ba);
         }
 
@@ -1351,13 +1277,13 @@ mod tests {
                 Fqk::rand(&mut rng),
                 Fqk::rand(&mut rng),
                 Fqk::rand(&mut rng),
-                Fqk::rand(&mut rng)
+                Fqk::rand(&mut rng),
             );
             let b = ComT::<F>(
                 Fqk::rand(&mut rng),
                 Fqk::rand(&mut rng),
                 Fqk::rand(&mut rng),
-                Fqk::rand(&mut rng)
+                Fqk::rand(&mut rng),
             );
             let ab = a - b;
             let ba = b - a;
@@ -1372,7 +1298,7 @@ mod tests {
             let mut rng = test_rng();
             let b = Com1::<F>(
                 G1Projective::rand(&mut rng).into_affine(),
-                G1Projective::rand(&mut rng).into_affine()
+                G1Projective::rand(&mut rng).into_affine(),
             );
             let scalar = Fr::rand(&mut rng);
             let b0 = b.0.mul(scalar);
@@ -1389,7 +1315,7 @@ mod tests {
             let mut rng = test_rng();
             let b = Com1::<F>(
                 G1Projective::rand(&mut rng).into_affine(),
-                G1Projective::rand(&mut rng).into_affine()
+                G1Projective::rand(&mut rng).into_affine(),
             );
             let scalar = Fr::rand(&mut rng);
             let b0 = b.0.mul(scalar);
@@ -1404,14 +1330,11 @@ mod tests {
         #[test]
         fn test_B_pairing_zero_G1() {
             let mut rng = test_rng();
-            let b1 = Com1::<F>(
-                G1Affine::zero(),
-                G1Affine::zero()
-            );
+            let b1 = Com1::<F>(G1Affine::zero(), G1Affine::zero());
             let b2 = Com2::<F>(
                 G2Projective::rand(&mut rng).into_affine(),
-                G2Projective::rand(&mut rng).into_affine()
-            );        
+                G2Projective::rand(&mut rng).into_affine(),
+            );
             let bt = ComT::pairing(b1.clone(), b2.clone());
 
             assert_eq!(bt.0, Fqk::one());
@@ -1426,12 +1349,9 @@ mod tests {
             let mut rng = test_rng();
             let b1 = Com1::<F>(
                 G1Projective::rand(&mut rng).into_affine(),
-                G1Projective::rand(&mut rng).into_affine()
+                G1Projective::rand(&mut rng).into_affine(),
             );
-            let b2 = Com2::<F>(
-                G2Affine::zero(),
-                G2Affine::zero()
-            );        
+            let b2 = Com2::<F>(G2Affine::zero(), G2Affine::zero());
             let bt = ComT::pairing(b1.clone(), b2.clone());
 
             assert_eq!(bt.0, Fqk::one());
@@ -1444,20 +1364,14 @@ mod tests {
         #[test]
         fn test_B_pairing_commit() {
             let mut rng = test_rng();
-            let b1 = Com1::<F>(
-                G1Affine::zero(),
-                G1Projective::rand(&mut rng).into_affine()
-            );
-            let b2 = Com2::<F>(
-                G2Affine::zero(),
-                G2Projective::rand(&mut rng).into_affine()
-            );
+            let b1 = Com1::<F>(G1Affine::zero(), G1Projective::rand(&mut rng).into_affine());
+            let b2 = Com2::<F>(G2Affine::zero(), G2Projective::rand(&mut rng).into_affine());
             let bt = ComT::pairing(b1.clone(), b2.clone());
 
             assert_eq!(bt.0, Fqk::one());
             assert_eq!(bt.1, Fqk::one());
             assert_eq!(bt.2, Fqk::one());
-            assert_eq!(bt.3, F::pairing::<G1Affine, G2Affine>(b1.1.clone(), b2.1.clone()));
+            assert_eq!(bt.3, F::pairing(b1.1.clone(), b2.1.clone()).0);
         }
 
         #[allow(non_snake_case)]
@@ -1466,18 +1380,18 @@ mod tests {
             let mut rng = test_rng();
             let b1 = Com1::<F>(
                 G1Projective::rand(&mut rng).into_affine(),
-                G1Projective::rand(&mut rng).into_affine()
+                G1Projective::rand(&mut rng).into_affine(),
             );
             let b2 = Com2::<F>(
                 G2Projective::rand(&mut rng).into_affine(),
-                G2Projective::rand(&mut rng).into_affine()
+                G2Projective::rand(&mut rng).into_affine(),
             );
             let bt = ComT::pairing(b1.clone(), b2.clone());
 
-            assert_eq!(bt.0, F::pairing::<G1Affine, G2Affine>(b1.0.clone(), b2.0.clone()));
-            assert_eq!(bt.1, F::pairing::<G1Affine, G2Affine>(b1.0.clone(), b2.1.clone()));
-            assert_eq!(bt.2, F::pairing::<G1Affine, G2Affine>(b1.1.clone(), b2.0.clone()));
-            assert_eq!(bt.3, F::pairing::<G1Affine, G2Affine>(b1.1.clone(), b2.1.clone()));        
+            assert_eq!(bt.0, F::pairing(b1.0.clone(), b2.0.clone()).0);
+            assert_eq!(bt.1, F::pairing(b1.0.clone(), b2.1.clone()).0);
+            assert_eq!(bt.2, F::pairing(b1.1.clone(), b2.0.clone()).0);
+            assert_eq!(bt.3, F::pairing(b1.1.clone(), b2.1.clone()).0);
         }
 
         #[allow(non_snake_case)]
@@ -1502,7 +1416,9 @@ mod tests {
             );
             let x = vec![x1, x2];
             let y = vec![y1, y2];
-            let exp: ComT<F> = vec![ ComT::<F>::pairing(x1, y1), ComT::<F>::pairing(x2, y2) ].into_iter().sum();
+            let exp: ComT<F> = vec![ComT::<F>::pairing(x1, y1), ComT::<F>::pairing(x2, y2)]
+                .into_iter()
+                .sum();
             let res: ComT<F> = ComT::<F>::pairing_sum(&x, &y);
 
             assert_eq!(exp, res);
@@ -1510,15 +1426,14 @@ mod tests {
 
         #[test]
         fn test_B_into_matrix() {
-
             let mut rng = test_rng();
             let b1 = Com1::<F>(
                 G1Projective::rand(&mut rng).into_affine(),
-                G1Projective::rand(&mut rng).into_affine()
+                G1Projective::rand(&mut rng).into_affine(),
             );
             let b2 = Com2::<F>(
                 G2Projective::rand(&mut rng).into_affine(),
-                G2Projective::rand(&mut rng).into_affine()
+                G2Projective::rand(&mut rng).into_affine(),
             );
             let bt = ComT::pairing(b1.clone(), b2.clone());
 
@@ -1531,26 +1446,25 @@ mod tests {
 
         #[test]
         fn test_B_from_matrix() {
-
             let mut rng = test_rng();
             let b1_vec = vec![
                 vec![G1Projective::rand(&mut rng).into_affine()],
-                vec![G1Projective::rand(&mut rng).into_affine()]
+                vec![G1Projective::rand(&mut rng).into_affine()],
             ];
 
             let b2_vec = vec![
                 vec![G2Projective::rand(&mut rng).into_affine()],
-                vec![G2Projective::rand(&mut rng).into_affine()]
+                vec![G2Projective::rand(&mut rng).into_affine()],
             ];
             let bt_vec = vec![
                 vec![
-                    F::pairing::<G1Affine, G2Affine>(b1_vec[0][0].clone(), b2_vec[0][0].clone()),
-                    F::pairing::<G1Affine, G2Affine>(b1_vec[0][0].clone(), b2_vec[1][0].clone()),
+                    F::pairing(b1_vec[0][0].clone(), b2_vec[0][0].clone()).0,
+                    F::pairing(b1_vec[0][0].clone(), b2_vec[1][0].clone()).0,
                 ],
                 vec![
-                    F::pairing::<G1Affine, G2Affine>(b1_vec[1][0].clone(), b2_vec[0][0].clone()),
-                    F::pairing::<G1Affine, G2Affine>(b1_vec[1][0].clone(), b2_vec[1][0].clone())
-                ]
+                    F::pairing(b1_vec[1][0].clone(), b2_vec[0][0].clone()).0,
+                    F::pairing(b1_vec[1][0].clone(), b2_vec[1][0].clone()).0,
+                ],
             ];
 
             let b1 = Com1::<F>::from(b1_vec.clone());
@@ -1570,8 +1484,14 @@ mod tests {
         #[test]
         fn test_batched_linear_maps() {
             let mut rng = test_rng();
-            let vec_g1 = vec![G1Projective::rand(&mut rng).into_affine(), G1Projective::rand(&mut rng).into_affine()];
-            let vec_g2 = vec![G2Projective::rand(&mut rng).into_affine(), G2Projective::rand(&mut rng).into_affine()];
+            let vec_g1 = vec![
+                G1Projective::rand(&mut rng).into_affine(),
+                G1Projective::rand(&mut rng).into_affine(),
+            ];
+            let vec_g2 = vec![
+                G2Projective::rand(&mut rng).into_affine(),
+                G2Projective::rand(&mut rng).into_affine(),
+            ];
             let vec_b1 = Com1::<F>::batch_linear_map(&vec_g1);
             let vec_b2 = Com2::<F>::batch_linear_map(&vec_g2);
 
@@ -1590,19 +1510,30 @@ mod tests {
             let vec_b1 = Com1::<F>::batch_scalar_linear_map(&vec_scalar, &key);
             let vec_b2 = Com2::<F>::batch_scalar_linear_map(&vec_scalar, &key);
 
-            assert_eq!(vec_b1[0], Com1::<F>::scalar_linear_map(&vec_scalar[0], &key));
-            assert_eq!(vec_b1[1], Com1::<F>::scalar_linear_map(&vec_scalar[1], &key));
-            assert_eq!(vec_b2[0], Com2::<F>::scalar_linear_map(&vec_scalar[0], &key));
-            assert_eq!(vec_b2[1], Com2::<F>::scalar_linear_map(&vec_scalar[1], &key));
+            assert_eq!(
+                vec_b1[0],
+                Com1::<F>::scalar_linear_map(&vec_scalar[0], &key)
+            );
+            assert_eq!(
+                vec_b1[1],
+                Com1::<F>::scalar_linear_map(&vec_scalar[1], &key)
+            );
+            assert_eq!(
+                vec_b2[0],
+                Com2::<F>::scalar_linear_map(&vec_scalar[0], &key)
+            );
+            assert_eq!(
+                vec_b2[1],
+                Com2::<F>::scalar_linear_map(&vec_scalar[1], &key)
+            );
         }
 
         #[test]
         fn test_PPE_linear_maps() {
-
             let mut rng = test_rng();
             let a1 = G1Projective::rand(&mut rng).into_affine();
             let a2 = G2Projective::rand(&mut rng).into_affine();
-            let at = F::pairing(a1.clone(), a2.clone());
+            let at = F::pairing(a1.clone(), a2.clone()).0;
             let b1 = Com1::<F>::linear_map(&a1);
             let b2 = Com2::<F>::linear_map(&a2);
             let bt = ComT::<F>::linear_map_PPE(&at);
@@ -1614,13 +1545,12 @@ mod tests {
             assert_eq!(bt.0, Fqk::one());
             assert_eq!(bt.1, Fqk::one());
             assert_eq!(bt.2, Fqk::one());
-            assert_eq!(bt.3, F::pairing(a1.clone(), a2.clone()));
+            assert_eq!(bt.3, F::pairing(a1.clone(), a2.clone()).0);
         }
 
         // Test that we're using the linear map that preserves witness-indistinguishability (see Ghadafi et al. 2010)
         #[test]
         fn test_MSMEG1_linear_maps() {
-
             let mut rng = test_rng();
             let key = CRS::<F>::generate_crs(&mut rng);
 
@@ -1637,14 +1567,16 @@ mod tests {
             assert_eq!(b2.1, (key.v[1].1 + key.g2_gen).mul(a2));
             assert_eq!(bt.0, Fqk::one());
             assert_eq!(bt.1, Fqk::one());
-            assert_eq!(bt.2, F::pairing(at.clone(), key.v[1].0.clone()));
-            assert_eq!(bt.3, F::pairing(at.clone(), key.v[1].1.clone() + key.g2_gen.clone()));
+            assert_eq!(bt.2, F::pairing(at.clone(), key.v[1].0.clone()).0);
+            assert_eq!(
+                bt.3,
+                F::pairing(at.clone(), key.v[1].1.clone() + key.g2_gen.clone()).0
+            );
         }
 
         // Test that we're using the linear map that preserves witness-indistinguishability (see Ghadafi et al. 2010)
         #[test]
         fn test_MSMEG2_linear_maps() {
-
             let mut rng = test_rng();
             let key = CRS::<F>::generate_crs(&mut rng);
 
@@ -1660,15 +1592,17 @@ mod tests {
             assert_eq!(b2.0, G2Affine::zero());
             assert_eq!(b2.1, a2);
             assert_eq!(bt.0, Fqk::one());
-            assert_eq!(bt.1, F::pairing(key.u[1].0.clone(), at.clone()));
+            assert_eq!(bt.1, F::pairing(key.u[1].0.clone(), at.clone()).0);
             assert_eq!(bt.2, Fqk::one());
-            assert_eq!(bt.3, F::pairing(key.u[1].1.clone() + key.g1_gen.clone(), at.clone()));
+            assert_eq!(
+                bt.3,
+                F::pairing(key.u[1].1.clone() + key.g1_gen.clone(), at.clone()).0
+            );
         }
 
         // Test that we're using the linear map that preserves witness-indistinguishability (see Ghadafi et al. 2010)
         #[test]
         fn test_QuadEqu_linear_maps() {
-
             let mut rng = test_rng();
             let key = CRS::<F>::generate_crs(&mut rng);
 
@@ -1678,132 +1612,181 @@ mod tests {
             let b1 = Com1::<F>::scalar_linear_map(&a1, &key);
             let b2 = Com2::<F>::scalar_linear_map(&a2, &key);
             let bt = ComT::<F>::linear_map_quad(&at, &key);
-            let W1 = Com1::<F>(
-                key.u[1].0,
-                key.u[1].1 + key.g1_gen
-            );
-            let W2 = Com2::<F>(
-                key.v[1].0,
-                key.v[1].1 + key.g2_gen
-            );
+            let W1 = Com1::<F>(key.u[1].0, (key.u[1].1 + key.g1_gen).into());
+            let W2 = Com2::<F>(key.v[1].0, (key.v[1].1 + key.g2_gen).into());
             assert_eq!(b1.0, W1.0.mul(a1));
             assert_eq!(b1.1, W1.1.mul(a1));
             assert_eq!(b2.0, W2.0.mul(a2));
             assert_eq!(b2.1, W2.1.mul(a2));
-            assert_eq!(bt, ComT::<F>::pairing(W1.scalar_mul(&a1), W2.scalar_mul(&a2)));
+            assert_eq!(
+                bt,
+                ComT::<F>::pairing(W1.scalar_mul(&a1), W2.scalar_mul(&a2))
+            );
             assert_eq!(bt, ComT::<F>::pairing(W1, W2.scalar_mul(&at)));
         }
     }
 
     mod matrix {
 
-        use ark_bls12_381::{Bls12_381 as F};
-        use ark_ff::{UniformRand, field_new};
-        use ark_ec::ProjectiveCurve;
+        use ark_bls12_381::Bls12_381 as F;
+        use ark_ec::pairing::Pairing;
+        use ark_ff::UniformRand;
+        use ark_std::ops::Mul;
+        use ark_std::str::FromStr;
         use ark_std::test_rng;
 
         use crate::data_structures::*;
 
-        type G1Affine = <F as PairingEngine>::G1Affine;
-        type G1Projective = <F as PairingEngine>::G1Projective;
-        type G2Affine = <F as PairingEngine>::G2Affine;
-        type G2Projective = <F as PairingEngine>::G2Projective;
-        type Fr = <F as PairingEngine>::Fr;
+        type G1Affine = <F as Pairing>::G1Affine;
+        type G1Projective = <F as Pairing>::G1;
+        type G2Affine = <F as Pairing>::G2Affine;
+        type G2Projective = <F as Pairing>::G2;
+        type Fr = <F as Pairing>::ScalarField;
 
         // Uses an affine group generator to produce an affine group element represented by the numeric string.
         #[allow(unused_macros)]
         macro_rules! affine_group_new {
             ($gen:expr, $strnum:tt) => {
-                $gen.mul(field_new!(Fr, $strnum)).into_affine()
-            }
+                $gen.mul(Fr::from_str($strnum).unwrap()).into_affine()
+            };
         }
 
         // Uses an affine group generator to produce a projective group element represented by the numeric string.
         #[allow(unused_macros)]
         macro_rules! projective_group_new {
             ($gen:expr, $strnum:tt) => {
-                $gen.mul(field_new!(Fr, $strnum))
-            }
+                $gen.mul(Fr::from_str($strnum).unwrap())
+            };
         }
 
         #[test]
         fn test_col_vec_to_vec() {
-            let mat = vec![vec![field_new!(Fr, "1")], vec![field_new!(Fr, "2")], vec![field_new!(Fr, "3")]];
+            let mat = vec![
+                vec![Fr::from_str("1").unwrap()],
+                vec![Fr::from_str("2").unwrap()],
+                vec![Fr::from_str("3").unwrap()],
+            ];
             let vec: Vec<Fr> = col_vec_to_vec(&mat);
-            let exp = vec![field_new!(Fr, "1"), field_new!(Fr, "2"), field_new!(Fr, "3")];
+            let exp = vec![
+                Fr::from_str("1").unwrap(),
+                Fr::from_str("2").unwrap(),
+                Fr::from_str("3").unwrap(),
+            ];
             assert_eq!(vec, exp);
         }
 
         #[test]
         fn test_vec_to_col_vec() {
-            let vec = vec![field_new!(Fr, "1"), field_new!(Fr, "2"), field_new!(Fr, "3")];
+            let vec = vec![
+                Fr::from_str("1").unwrap(),
+                Fr::from_str("2").unwrap(),
+                Fr::from_str("3").unwrap(),
+            ];
             let mat: Matrix<Fr> = vec_to_col_vec(&vec);
-            let exp = vec![vec![field_new!(Fr, "1")], vec![field_new!(Fr, "2")], vec![field_new!(Fr, "3")]];
+            let exp = vec![
+                vec![Fr::from_str("1").unwrap()],
+                vec![Fr::from_str("2").unwrap()],
+                vec![Fr::from_str("3").unwrap()],
+            ];
             assert_eq!(mat, exp);
         }
 
         #[test]
         fn test_field_matrix_left_mul_entry() {
-
             // 1 x 3 (row) vector
             let one = Fr::one();
-            let lhs: Matrix<Fr> = vec![vec![one, field_new!(Fr, "2"), field_new!(Fr, "3")]];
+            let lhs: Matrix<Fr> = vec![vec![
+                one,
+                Fr::from_str("2").unwrap(),
+                Fr::from_str("3").unwrap(),
+            ]];
             // 3 x 1 (column) vector
             let rhs: Matrix<Fr> = vec![
-                vec![field_new!(Fr, "4")],
-                vec![field_new!(Fr, "5")],
-                vec![field_new!(Fr, "6")]
+                vec![Fr::from_str("4").unwrap()],
+                vec![Fr::from_str("5").unwrap()],
+                vec![Fr::from_str("6").unwrap()],
             ];
-            let exp: Matrix<Fr> = vec![vec![field_new!(Fr, "32")]];
+            let exp: Matrix<Fr> = vec![vec![Fr::from_str("32").unwrap()]];
             let res: Matrix<Fr> = rhs.left_mul(&lhs, false);
 
             // 1 x 1 resulting matrix
             assert_eq!(res.len(), 1);
             assert_eq!(res[0].len(), 1);
-       
+
             assert_eq!(exp, res);
         }
 
         #[test]
         fn test_field_matrix_right_mul_entry() {
-
             // 1 x 3 (row) vector
             let one = Fr::one();
-            let lhs: Matrix<Fr> = vec![vec![one, field_new!(Fr, "2"), field_new!(Fr, "3")]];
+            let lhs: Matrix<Fr> = vec![vec![
+                one,
+                Fr::from_str("2").unwrap(),
+                Fr::from_str("3").unwrap(),
+            ]];
             // 3 x 1 (column) vector
             let rhs: Matrix<Fr> = vec![
-                vec![field_new!(Fr, "4")],
-                vec![field_new!(Fr, "5")],
-                vec![field_new!(Fr, "6")]
+                vec![Fr::from_str("4").unwrap()],
+                vec![Fr::from_str("5").unwrap()],
+                vec![Fr::from_str("6").unwrap()],
             ];
-            let exp: Matrix<Fr> = vec![vec![field_new!(Fr, "32")]];
+            let exp: Matrix<Fr> = vec![vec![Fr::from_str("32").unwrap()]];
             let res: Matrix<Fr> = lhs.right_mul(&rhs, false);
 
             // 1 x 1 resulting matrix
             assert_eq!(res.len(), 1);
             assert_eq!(res[0].len(), 1);
-       
+
             assert_eq!(exp, res);
         }
 
         #[test]
         fn test_field_matrix_left_mul() {
-
             // 2 x 3 matrix
             let one = Fr::one();
             let lhs: Matrix<Fr> = vec![
-                vec![one, field_new!(Fr, "2"), field_new!(Fr, "3")],
-                vec![field_new!(Fr, "4"), field_new!(Fr, "5"), field_new!(Fr, "6")]
+                vec![one, Fr::from_str("2").unwrap(), Fr::from_str("3").unwrap()],
+                vec![
+                    Fr::from_str("4").unwrap(),
+                    Fr::from_str("5").unwrap(),
+                    Fr::from_str("6").unwrap(),
+                ],
             ];
             // 3 x 4 matrix
             let rhs: Matrix<Fr> = vec![
-                vec![field_new!(Fr, "7"), field_new!(Fr, "8"), field_new!(Fr, "9"), field_new!(Fr, "10")],
-                vec![field_new!(Fr, "11"), field_new!(Fr, "12"), field_new!(Fr, "13"), field_new!(Fr, "14")],
-                vec![field_new!(Fr, "15"), field_new!(Fr, "16"), field_new!(Fr, "17"), field_new!(Fr, "18")]
+                vec![
+                    Fr::from_str("7").unwrap(),
+                    Fr::from_str("8").unwrap(),
+                    Fr::from_str("9").unwrap(),
+                    Fr::from_str("10").unwrap(),
+                ],
+                vec![
+                    Fr::from_str("11").unwrap(),
+                    Fr::from_str("12").unwrap(),
+                    Fr::from_str("13").unwrap(),
+                    Fr::from_str("14").unwrap(),
+                ],
+                vec![
+                    Fr::from_str("15").unwrap(),
+                    Fr::from_str("16").unwrap(),
+                    Fr::from_str("17").unwrap(),
+                    Fr::from_str("18").unwrap(),
+                ],
             ];
             let exp: Matrix<Fr> = vec![
-                vec![field_new!(Fr, "74"), field_new!(Fr, "80"), field_new!(Fr, "86"), field_new!(Fr, "92")],
-                vec![field_new!(Fr, "173"), field_new!(Fr, "188"), field_new!(Fr, "203"), field_new!(Fr, "218")]
+                vec![
+                    Fr::from_str("74").unwrap(),
+                    Fr::from_str("80").unwrap(),
+                    Fr::from_str("86").unwrap(),
+                    Fr::from_str("92").unwrap(),
+                ],
+                vec![
+                    Fr::from_str("173").unwrap(),
+                    Fr::from_str("188").unwrap(),
+                    Fr::from_str("203").unwrap(),
+                    Fr::from_str("218").unwrap(),
+                ],
             ];
             let res: Matrix<Fr> = rhs.left_mul(&lhs, false);
 
@@ -1817,22 +1800,50 @@ mod tests {
 
         #[test]
         fn test_field_matrix_right_mul() {
-
             // 2 x 3 matrix
             let one = Fr::one();
             let lhs: Matrix<Fr> = vec![
-                vec![one, field_new!(Fr, "2"), field_new!(Fr, "3")],
-                vec![field_new!(Fr, "4"), field_new!(Fr, "5"), field_new!(Fr, "6")]
+                vec![one, Fr::from_str("2").unwrap(), Fr::from_str("3").unwrap()],
+                vec![
+                    Fr::from_str("4").unwrap(),
+                    Fr::from_str("5").unwrap(),
+                    Fr::from_str("6").unwrap(),
+                ],
             ];
             // 3 x 4 matrix
             let rhs: Matrix<Fr> = vec![
-                vec![field_new!(Fr, "7"), field_new!(Fr, "8"), field_new!(Fr, "9"), field_new!(Fr, "10")],
-                vec![field_new!(Fr, "11"), field_new!(Fr, "12"), field_new!(Fr, "13"), field_new!(Fr, "14")],
-                vec![field_new!(Fr, "15"), field_new!(Fr, "16"), field_new!(Fr, "17"), field_new!(Fr, "18")]
+                vec![
+                    Fr::from_str("7").unwrap(),
+                    Fr::from_str("8").unwrap(),
+                    Fr::from_str("9").unwrap(),
+                    Fr::from_str("10").unwrap(),
+                ],
+                vec![
+                    Fr::from_str("11").unwrap(),
+                    Fr::from_str("12").unwrap(),
+                    Fr::from_str("13").unwrap(),
+                    Fr::from_str("14").unwrap(),
+                ],
+                vec![
+                    Fr::from_str("15").unwrap(),
+                    Fr::from_str("16").unwrap(),
+                    Fr::from_str("17").unwrap(),
+                    Fr::from_str("18").unwrap(),
+                ],
             ];
             let exp: Matrix<Fr> = vec![
-                vec![field_new!(Fr, "74"), field_new!(Fr, "80"), field_new!(Fr, "86"), field_new!(Fr, "92")],
-                vec![field_new!(Fr, "173"), field_new!(Fr, "188"), field_new!(Fr, "203"), field_new!(Fr, "218")]
+                vec![
+                    Fr::from_str("74").unwrap(),
+                    Fr::from_str("80").unwrap(),
+                    Fr::from_str("86").unwrap(),
+                    Fr::from_str("92").unwrap(),
+                ],
+                vec![
+                    Fr::from_str("173").unwrap(),
+                    Fr::from_str("188").unwrap(),
+                    Fr::from_str("203").unwrap(),
+                    Fr::from_str("218").unwrap(),
+                ],
             ];
             let res: Matrix<Fr> = lhs.right_mul(&rhs, false);
 
@@ -1844,25 +1855,52 @@ mod tests {
             assert_eq!(exp, res);
         }
 
-
         #[test]
         fn test_field_matrix_left_mul_par() {
-
             // 2 x 3 matrix
             let one = Fr::one();
             let lhs: Matrix<Fr> = vec![
-                vec![one, field_new!(Fr, "2"), field_new!(Fr, "3")],
-                vec![field_new!(Fr, "4"), field_new!(Fr, "5"), field_new!(Fr, "6")]
+                vec![one, Fr::from_str("2").unwrap(), Fr::from_str("3").unwrap()],
+                vec![
+                    Fr::from_str("4").unwrap(),
+                    Fr::from_str("5").unwrap(),
+                    Fr::from_str("6").unwrap(),
+                ],
             ];
             // 3 x 4 matrix
             let rhs: Matrix<Fr> = vec![
-                vec![field_new!(Fr, "7"), field_new!(Fr, "8"), field_new!(Fr, "9"), field_new!(Fr, "10")],
-                vec![field_new!(Fr, "11"), field_new!(Fr, "12"), field_new!(Fr, "13"), field_new!(Fr, "14")],
-                vec![field_new!(Fr, "15"), field_new!(Fr, "16"), field_new!(Fr, "17"), field_new!(Fr, "18")]
+                vec![
+                    Fr::from_str("7").unwrap(),
+                    Fr::from_str("8").unwrap(),
+                    Fr::from_str("9").unwrap(),
+                    Fr::from_str("10").unwrap(),
+                ],
+                vec![
+                    Fr::from_str("11").unwrap(),
+                    Fr::from_str("12").unwrap(),
+                    Fr::from_str("13").unwrap(),
+                    Fr::from_str("14").unwrap(),
+                ],
+                vec![
+                    Fr::from_str("15").unwrap(),
+                    Fr::from_str("16").unwrap(),
+                    Fr::from_str("17").unwrap(),
+                    Fr::from_str("18").unwrap(),
+                ],
             ];
             let exp: Matrix<Fr> = vec![
-                vec![field_new!(Fr, "74"), field_new!(Fr, "80"), field_new!(Fr, "86"), field_new!(Fr, "92")],
-                vec![field_new!(Fr, "173"), field_new!(Fr, "188"), field_new!(Fr, "203"), field_new!(Fr, "218")]
+                vec![
+                    Fr::from_str("74").unwrap(),
+                    Fr::from_str("80").unwrap(),
+                    Fr::from_str("86").unwrap(),
+                    Fr::from_str("92").unwrap(),
+                ],
+                vec![
+                    Fr::from_str("173").unwrap(),
+                    Fr::from_str("188").unwrap(),
+                    Fr::from_str("203").unwrap(),
+                    Fr::from_str("218").unwrap(),
+                ],
             ];
             let res: Matrix<Fr> = rhs.left_mul(&lhs, true);
 
@@ -1876,22 +1914,50 @@ mod tests {
 
         #[test]
         fn test_field_matrix_right_mul_par() {
-
             // 2 x 3 matrix
             let one = Fr::one();
             let lhs: Matrix<Fr> = vec![
-                vec![one, field_new!(Fr, "2"), field_new!(Fr, "3")],
-                vec![field_new!(Fr, "4"), field_new!(Fr, "5"), field_new!(Fr, "6")]
+                vec![one, Fr::from_str("2").unwrap(), Fr::from_str("3").unwrap()],
+                vec![
+                    Fr::from_str("4").unwrap(),
+                    Fr::from_str("5").unwrap(),
+                    Fr::from_str("6").unwrap(),
+                ],
             ];
             // 3 x 4 matrix
             let rhs: Matrix<Fr> = vec![
-                vec![field_new!(Fr, "7"), field_new!(Fr, "8"), field_new!(Fr, "9"), field_new!(Fr, "10")],
-                vec![field_new!(Fr, "11"), field_new!(Fr, "12"), field_new!(Fr, "13"), field_new!(Fr, "14")],
-                vec![field_new!(Fr, "15"), field_new!(Fr, "16"), field_new!(Fr, "17"), field_new!(Fr, "18")]
+                vec![
+                    Fr::from_str("7").unwrap(),
+                    Fr::from_str("8").unwrap(),
+                    Fr::from_str("9").unwrap(),
+                    Fr::from_str("10").unwrap(),
+                ],
+                vec![
+                    Fr::from_str("11").unwrap(),
+                    Fr::from_str("12").unwrap(),
+                    Fr::from_str("13").unwrap(),
+                    Fr::from_str("14").unwrap(),
+                ],
+                vec![
+                    Fr::from_str("15").unwrap(),
+                    Fr::from_str("16").unwrap(),
+                    Fr::from_str("17").unwrap(),
+                    Fr::from_str("18").unwrap(),
+                ],
             ];
             let exp: Matrix<Fr> = vec![
-                vec![field_new!(Fr, "74"), field_new!(Fr, "80"), field_new!(Fr, "86"), field_new!(Fr, "92")],
-                vec![field_new!(Fr, "173"), field_new!(Fr, "188"), field_new!(Fr, "203"), field_new!(Fr, "218")]
+                vec![
+                    Fr::from_str("74").unwrap(),
+                    Fr::from_str("80").unwrap(),
+                    Fr::from_str("86").unwrap(),
+                    Fr::from_str("92").unwrap(),
+                ],
+                vec![
+                    Fr::from_str("173").unwrap(),
+                    Fr::from_str("188").unwrap(),
+                    Fr::from_str("203").unwrap(),
+                    Fr::from_str("218").unwrap(),
+                ],
             ];
             let res: Matrix<Fr> = lhs.right_mul(&rhs, true);
 
@@ -1906,73 +1972,100 @@ mod tests {
         #[allow(non_snake_case)]
         #[test]
         fn test_B1_matrix_left_mul_entry() {
-
             // 1 x 3 (row) vector
             let one = Fr::one();
             let mut rng = test_rng();
             let g1gen = G1Projective::rand(&mut rng).into_affine();
-            
-            let lhs: Matrix<Fr> = vec![vec![one, field_new!(Fr, "2"), field_new!(Fr, "3")]];
+
+            let lhs: Matrix<Fr> = vec![vec![
+                one,
+                Fr::from_str("2").unwrap(),
+                Fr::from_str("3").unwrap(),
+            ]];
             // 3 x 1 (column) vector
             let rhs: Matrix<Com1<F>> = vec![
-                vec![ Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "4") ) ],
-                vec![ Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "5") ) ],
-                vec![ Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "6") ) ]
+                vec![Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "4"))],
+                vec![Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "5"))],
+                vec![Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "6"))],
             ];
-            let exp: Matrix<Com1<F>> = vec![vec![ Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "32") )]];
+            let exp: Matrix<Com1<F>> = vec![vec![Com1::<F>(
+                G1Affine::zero(),
+                affine_group_new!(g1gen, "32"),
+            )]];
             let res: Matrix<Com1<F>> = rhs.left_mul(&lhs, false);
-            
+
             // 1 x 1 resulting matrix
             assert_eq!(res.len(), 1);
             assert_eq!(res[0].len(), 1);
-       
+
             assert_eq!(exp, res);
         }
 
         #[allow(non_snake_case)]
         #[test]
         fn test_B1_matrix_right_mul_entry() {
-
             // 1 x 3 (row) vector
             let mut rng = test_rng();
             let g1gen = G1Projective::rand(&mut rng).into_affine();
             let lhs: Matrix<Com1<F>> = vec![vec![
-                Com1::<F>( G1Affine::zero(), g1gen),
-                Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "2")),
-                Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "3"))
+                Com1::<F>(G1Affine::zero(), g1gen),
+                Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "2")),
+                Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "3")),
             ]];
             // 3 x 1 (column) vector
             let rhs: Matrix<Fr> = vec![
-                vec![field_new!(Fr, "4")],
-                vec![field_new!(Fr, "5")],
-                vec![field_new!(Fr, "6")]
+                vec![Fr::from_str("4").unwrap()],
+                vec![Fr::from_str("5").unwrap()],
+                vec![Fr::from_str("6").unwrap()],
             ];
-            let exp: Matrix<Com1<F>> = vec![vec![ Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "32") ) ]];
+            let exp: Matrix<Com1<F>> = vec![vec![Com1::<F>(
+                G1Affine::zero(),
+                affine_group_new!(g1gen, "32"),
+            )]];
             let res: Matrix<Com1<F>> = lhs.right_mul(&rhs, false);
-            
+
             // 1 x 1 resulting matrix
             assert_eq!(res.len(), 1);
             assert_eq!(res[0].len(), 1);
-       
+
             assert_eq!(exp, res);
         }
 
         #[test]
         fn test_field_matrix_scalar_mul() {
-
             // 3 x 3 matrices
             let one = Fr::one();
-            let scalar: Fr = field_new!(Fr, "3");
+            let scalar: Fr = Fr::from_str("3").unwrap();
             let mat: Matrix<Fr> = vec![
-                vec![one, field_new!(Fr, "2"), field_new!(Fr, "3")],
-                vec![field_new!(Fr, "4"), field_new!(Fr, "5"), field_new!(Fr, "6")],
-                vec![field_new!(Fr, "7"), field_new!(Fr, "8"), field_new!(Fr, "9")]
+                vec![one, Fr::from_str("2").unwrap(), Fr::from_str("3").unwrap()],
+                vec![
+                    Fr::from_str("4").unwrap(),
+                    Fr::from_str("5").unwrap(),
+                    Fr::from_str("6").unwrap(),
+                ],
+                vec![
+                    Fr::from_str("7").unwrap(),
+                    Fr::from_str("8").unwrap(),
+                    Fr::from_str("9").unwrap(),
+                ],
             ];
 
             let exp: Matrix<Fr> = vec![
-                vec![field_new!(Fr, "3"), field_new!(Fr, "6"), field_new!(Fr, "9")],
-                vec![field_new!(Fr, "12"), field_new!(Fr, "15"), field_new!(Fr, "18")],
-                vec![field_new!(Fr, "21"), field_new!(Fr, "24"), field_new!(Fr, "27")]
+                vec![
+                    Fr::from_str("3").unwrap(),
+                    Fr::from_str("6").unwrap(),
+                    Fr::from_str("9").unwrap(),
+                ],
+                vec![
+                    Fr::from_str("12").unwrap(),
+                    Fr::from_str("15").unwrap(),
+                    Fr::from_str("18").unwrap(),
+                ],
+                vec![
+                    Fr::from_str("21").unwrap(),
+                    Fr::from_str("24").unwrap(),
+                    Fr::from_str("27").unwrap(),
+                ],
             ];
             let res: Matrix<Fr> = mat.scalar_mul(&scalar);
 
@@ -1981,8 +2074,7 @@ mod tests {
 
         #[test]
         fn test_B1_matrix_scalar_mul() {
-
-            let scalar: Fr = field_new!(Fr, "3");
+            let scalar: Fr = Fr::from_str("3").unwrap();
 
             // 3 x 3 matrix of Com1 elements (0, 3)
             let mut rng = test_rng();
@@ -1992,8 +2084,7 @@ mod tests {
             for i in 0..3 {
                 mat.push(Vec::with_capacity(3));
                 for _ in 0..3 {
-
-                    mat[i].push( Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "1") ) );
+                    mat[i].push(Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "1")));
                 }
             }
 
@@ -2001,7 +2092,7 @@ mod tests {
             for i in 0..3 {
                 exp.push(Vec::with_capacity(3));
                 for _ in 0..3 {
-                    exp[i].push( Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "3") ) );
+                    exp[i].push(Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "3")));
                 }
             }
 
@@ -2012,8 +2103,7 @@ mod tests {
 
         #[test]
         fn test_B2_matrix_scalar_mul() {
-
-            let scalar: Fr = field_new!(Fr, "3");
+            let scalar: Fr = Fr::from_str("3").unwrap();
 
             // 3 x 3 matrix of Com1 elements (0, 3)
             let mut rng = test_rng();
@@ -2023,8 +2113,7 @@ mod tests {
             for i in 0..3 {
                 mat.push(Vec::with_capacity(3));
                 for _ in 0..3 {
-
-                    mat[i].push( Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "1") ) );
+                    mat[i].push(Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "1")));
                 }
             }
 
@@ -2032,7 +2121,7 @@ mod tests {
             for i in 0..3 {
                 exp.push(Vec::with_capacity(3));
                 for _ in 0..3 {
-                    exp[i].push( Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "3") ) );
+                    exp[i].push(Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "3")));
                 }
             }
 
@@ -2047,15 +2136,15 @@ mod tests {
             let g1gen = G1Projective::rand(&mut rng).into_affine();
             // 1 x 3 (row) vector
             let mat: Matrix<Com1<F>> = vec![vec![
-                Com1::<F>( G1Affine::zero(), g1gen),
-                Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "2")),
-                Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "3"))
+                Com1::<F>(G1Affine::zero(), g1gen),
+                Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "2")),
+                Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "3")),
             ]];
             // 3 x 1 transpose (column) vector
             let exp: Matrix<Com1<F>> = vec![
-                vec![Com1::<F>( G1Affine::zero(), g1gen)],
-                vec![Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "2"))],
-                vec![Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "3"))]
+                vec![Com1::<F>(G1Affine::zero(), g1gen)],
+                vec![Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "2"))],
+                vec![Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "3"))],
             ];
             let res: Matrix<Com1<F>> = mat.transpose();
 
@@ -2068,45 +2157,43 @@ mod tests {
 
         #[test]
         fn test_B1_matrix_transpose() {
-
             // 3 x 3 matrix
             let mut rng = test_rng();
             let g1gen = G1Projective::rand(&mut rng).into_affine();
             let mat: Matrix<Com1<F>> = vec![
                 vec![
-                    Com1::<F>( G1Affine::zero(), g1gen ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "2") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "3") )
+                    Com1::<F>(G1Affine::zero(), g1gen),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "2")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "3")),
                 ],
                 vec![
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "4") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "5") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "6") )
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "4")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "5")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "6")),
                 ],
                 vec![
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "7") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "8") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "9") )
-                ]
-
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "7")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "8")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "9")),
+                ],
             ];
             // 3 x 3 transpose matrix
             let exp: Matrix<Com1<F>> = vec![
                 vec![
-                    Com1::<F>( G1Affine::zero(), g1gen ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "4") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "7") )
+                    Com1::<F>(G1Affine::zero(), g1gen),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "4")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "7")),
                 ],
                 vec![
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "2") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "5") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "8") )
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "2")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "5")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "8")),
                 ],
                 vec![
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "3") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "6") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "9") )
-                ]
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "3")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "6")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "9")),
+                ],
             ];
             let res: Matrix<Com1<F>> = mat.transpose();
 
@@ -2124,15 +2211,15 @@ mod tests {
             let g2gen = G2Projective::rand(&mut rng).into_affine();
             // 1 x 3 (row) vector
             let mat: Matrix<Com2<F>> = vec![vec![
-                Com2::<F>( G2Affine::zero(), g2gen),
-                Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "2")),
-                Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "3"))
+                Com2::<F>(G2Affine::zero(), g2gen),
+                Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "2")),
+                Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "3")),
             ]];
             // 3 x 1 transpose (column) vector
             let exp: Matrix<Com2<F>> = vec![
-                vec![Com2::<F>( G2Affine::zero(), g2gen)],
-                vec![Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "2"))],
-                vec![Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "3"))]
+                vec![Com2::<F>(G2Affine::zero(), g2gen)],
+                vec![Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "2"))],
+                vec![Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "3"))],
             ];
             let res: Matrix<Com2<F>> = mat.transpose();
 
@@ -2145,45 +2232,43 @@ mod tests {
 
         #[test]
         fn test_B2_matrix_transpose() {
-
             // 3 x 3 matrix
             let mut rng = test_rng();
             let g2gen = G2Projective::rand(&mut rng).into_affine();
             let mat: Matrix<Com2<F>> = vec![
                 vec![
-                    Com2::<F>( G2Affine::zero(), g2gen ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "2") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "3") )
+                    Com2::<F>(G2Affine::zero(), g2gen),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "2")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "3")),
                 ],
                 vec![
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "4") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "5") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "6") )
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "4")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "5")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "6")),
                 ],
                 vec![
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "7") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "8") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "9") )
-                ]
-
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "7")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "8")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "9")),
+                ],
             ];
             // 3 x 3 transpose matrix
             let exp: Matrix<Com2<F>> = vec![
                 vec![
-                    Com2::<F>( G2Affine::zero(), g2gen ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "4") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "7") )
+                    Com2::<F>(G2Affine::zero(), g2gen),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "4")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "7")),
                 ],
                 vec![
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "2") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "5") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "8") )
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "2")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "5")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "8")),
                 ],
                 vec![
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "3") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "6") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "9") )
-                ]
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "3")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "6")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "9")),
+                ],
             ];
             let res: Matrix<Com2<F>> = mat.transpose();
 
@@ -2197,16 +2282,19 @@ mod tests {
 
         #[test]
         fn test_field_transpose_vec() {
-
             // 1 x 3 (row) vector
             let one = Fr::one();
-            let mat: Matrix<Fr> = vec![vec![one, field_new!(Fr, "2"), field_new!(Fr, "3")]];
+            let mat: Matrix<Fr> = vec![vec![
+                one,
+                Fr::from_str("2").unwrap(),
+                Fr::from_str("3").unwrap(),
+            ]];
 
             // 3 x 1 transpose (column) vector
             let exp: Matrix<Fr> = vec![
                 vec![one],
-                vec![field_new!(Fr, "2")],
-                vec![field_new!(Fr, "3")]
+                vec![Fr::from_str("2").unwrap()],
+                vec![Fr::from_str("3").unwrap()],
             ];
             let res: Matrix<Fr> = mat.transpose();
 
@@ -2220,20 +2308,34 @@ mod tests {
 
         #[test]
         fn test_field_matrix_transpose() {
-
             // 3 x 3 matrix
             let one = Fr::one();
             let mat: Matrix<Fr> = vec![
-                vec![one, field_new!(Fr, "2"), field_new!(Fr, "3")],
-                vec![field_new!(Fr, "4"), field_new!(Fr, "5"), field_new!(Fr, "6")],
-                vec![field_new!(Fr, "7"), field_new!(Fr, "8"), field_new!(Fr, "9")]
-
+                vec![one, Fr::from_str("2").unwrap(), Fr::from_str("3").unwrap()],
+                vec![
+                    Fr::from_str("4").unwrap(),
+                    Fr::from_str("5").unwrap(),
+                    Fr::from_str("6").unwrap(),
+                ],
+                vec![
+                    Fr::from_str("7").unwrap(),
+                    Fr::from_str("8").unwrap(),
+                    Fr::from_str("9").unwrap(),
+                ],
             ];
             // 3 x 3 transpose matrix
             let exp: Matrix<Fr> = vec![
-                vec![one, field_new!(Fr, "4"), field_new!(Fr, "7")],
-                vec![field_new!(Fr, "2"), field_new!(Fr, "5"), field_new!(Fr, "8")],
-                vec![field_new!(Fr, "3"), field_new!(Fr, "6"), field_new!(Fr, "9")]
+                vec![one, Fr::from_str("4").unwrap(), Fr::from_str("7").unwrap()],
+                vec![
+                    Fr::from_str("2").unwrap(),
+                    Fr::from_str("5").unwrap(),
+                    Fr::from_str("8").unwrap(),
+                ],
+                vec![
+                    Fr::from_str("3").unwrap(),
+                    Fr::from_str("6").unwrap(),
+                    Fr::from_str("9").unwrap(),
+                ],
             ];
             let res: Matrix<Fr> = mat.transpose();
 
@@ -2247,20 +2349,38 @@ mod tests {
 
         #[test]
         fn test_field_matrix_neg() {
-
             // 3 x 3 matrix
             let one = Fr::one();
             let mat: Matrix<Fr> = vec![
-                vec![one, field_new!(Fr, "2"), field_new!(Fr, "3")],
-                vec![field_new!(Fr, "4"), field_new!(Fr, "5"), field_new!(Fr, "6")],
-                vec![field_new!(Fr, "7"), field_new!(Fr, "8"), field_new!(Fr, "9")]
-
+                vec![one, Fr::from_str("2").unwrap(), Fr::from_str("3").unwrap()],
+                vec![
+                    Fr::from_str("4").unwrap(),
+                    Fr::from_str("5").unwrap(),
+                    Fr::from_str("6").unwrap(),
+                ],
+                vec![
+                    Fr::from_str("7").unwrap(),
+                    Fr::from_str("8").unwrap(),
+                    Fr::from_str("9").unwrap(),
+                ],
             ];
             // 3 x 3 transpose matrix
             let exp: Matrix<Fr> = vec![
-                vec![-one, field_new!(Fr, "-2"), field_new!(Fr, "-3")],
-                vec![field_new!(Fr, "-4"), field_new!(Fr, "-5"), field_new!(Fr, "-6")],
-                vec![field_new!(Fr, "-7"), field_new!(Fr, "-8"), field_new!(Fr, "-9")]
+                vec![
+                    -one,
+                    -Fr::from_str("2").unwrap(),
+                    -Fr::from_str("3").unwrap(),
+                ],
+                vec![
+                    -Fr::from_str("4").unwrap(),
+                    -Fr::from_str("5").unwrap(),
+                    -Fr::from_str("6").unwrap(),
+                ],
+                vec![
+                    -Fr::from_str("7").unwrap(),
+                    -Fr::from_str("8").unwrap(),
+                    -Fr::from_str("9").unwrap(),
+                ],
             ];
             let res: Matrix<Fr> = mat.neg();
 
@@ -2272,48 +2392,45 @@ mod tests {
             assert_eq!(exp, res);
         }
 
-
         #[test]
         fn test_B1_matrix_neg() {
-
             // 3 x 3 matrix
             let mut rng = test_rng();
             let g1gen = G1Projective::rand(&mut rng).into_affine();
             let mat: Matrix<Com1<F>> = vec![
                 vec![
-                    Com1::<F>( G1Affine::zero(), g1gen ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "2") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "3") )
+                    Com1::<F>(G1Affine::zero(), g1gen),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "2")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "3")),
                 ],
                 vec![
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "4") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "5") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "6") )
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "4")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "5")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "6")),
                 ],
                 vec![
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "7") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "8") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "9") )
-                ]
-
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "7")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "8")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "9")),
+                ],
             ];
             // 3 x 3 transpose matrix
             let exp: Matrix<Com1<F>> = vec![
                 vec![
-                    Com1::<F>( G1Affine::zero(), -g1gen ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "-2") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "-3") )
+                    Com1::<F>(G1Affine::zero(), -g1gen),
+                    Com1::<F>(G1Affine::zero(), -affine_group_new!(g1gen, "2")),
+                    Com1::<F>(G1Affine::zero(), -affine_group_new!(g1gen, "3")),
                 ],
                 vec![
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "-4") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "-5") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "-6") )
+                    Com1::<F>(G1Affine::zero(), -affine_group_new!(g1gen, "4")),
+                    Com1::<F>(G1Affine::zero(), -affine_group_new!(g1gen, "5")),
+                    Com1::<F>(G1Affine::zero(), -affine_group_new!(g1gen, "6")),
                 ],
                 vec![
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "-7") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "-8") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "-9") )
-                ]
+                    Com1::<F>(G1Affine::zero(), -affine_group_new!(g1gen, "7")),
+                    Com1::<F>(G1Affine::zero(), -affine_group_new!(g1gen, "8")),
+                    Com1::<F>(G1Affine::zero(), -affine_group_new!(g1gen, "9")),
+                ],
             ];
             let res: Matrix<Com1<F>> = mat.neg();
 
@@ -2327,45 +2444,43 @@ mod tests {
 
         #[test]
         fn test_B2_matrix_neg() {
-
             // 3 x 3 matrix
             let mut rng = test_rng();
             let g2gen = G2Projective::rand(&mut rng).into_affine();
             let mat: Matrix<Com2<F>> = vec![
                 vec![
-                    Com2::<F>( G2Affine::zero(), g2gen ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "2") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "3") )
+                    Com2::<F>(G2Affine::zero(), g2gen),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "2")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "3")),
                 ],
                 vec![
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "4") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "5") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "6") )
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "4")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "5")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "6")),
                 ],
                 vec![
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "7") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "8") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "9") )
-                ]
-
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "7")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "8")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "9")),
+                ],
             ];
             // 3 x 3 transpose matrix
             let exp: Matrix<Com2<F>> = vec![
                 vec![
-                    Com2::<F>( G2Affine::zero(), -g2gen ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "-2") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "-3") )
+                    Com2::<F>(G2Affine::zero(), -g2gen),
+                    Com2::<F>(G2Affine::zero(), -affine_group_new!(g2gen, "2")),
+                    Com2::<F>(G2Affine::zero(), -affine_group_new!(g2gen, "3")),
                 ],
                 vec![
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "-4") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "-5") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "-6") )
+                    Com2::<F>(G2Affine::zero(), -affine_group_new!(g2gen, "4")),
+                    Com2::<F>(G2Affine::zero(), -affine_group_new!(g2gen, "5")),
+                    Com2::<F>(G2Affine::zero(), -affine_group_new!(g2gen, "6")),
                 ],
                 vec![
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "-7") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "-8") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "-9") )
-                ]
+                    Com2::<F>(G2Affine::zero(), -affine_group_new!(g2gen, "7")),
+                    Com2::<F>(G2Affine::zero(), -affine_group_new!(g2gen, "8")),
+                    Com2::<F>(G2Affine::zero(), -affine_group_new!(g2gen, "9")),
+                ],
             ];
             let res: Matrix<Com2<F>> = mat.neg();
 
@@ -2378,24 +2493,55 @@ mod tests {
         }
         #[test]
         fn test_field_matrix_add() {
-
             // 3 x 3 matrices
             let one = Fr::one();
             let lhs: Matrix<Fr> = vec![
-                vec![one, field_new!(Fr, "2"), field_new!(Fr, "3")],
-                vec![field_new!(Fr, "4"), field_new!(Fr, "5"), field_new!(Fr, "6")],
-                vec![field_new!(Fr, "7"), field_new!(Fr, "8"), field_new!(Fr, "9")]
+                vec![one, Fr::from_str("2").unwrap(), Fr::from_str("3").unwrap()],
+                vec![
+                    Fr::from_str("4").unwrap(),
+                    Fr::from_str("5").unwrap(),
+                    Fr::from_str("6").unwrap(),
+                ],
+                vec![
+                    Fr::from_str("7").unwrap(),
+                    Fr::from_str("8").unwrap(),
+                    Fr::from_str("9").unwrap(),
+                ],
             ];
             let rhs: Matrix<Fr> = vec![
-                vec![field_new!(Fr, "10"), field_new!(Fr, "11"), field_new!(Fr, "12")],
-                vec![field_new!(Fr, "13"), field_new!(Fr, "14"), field_new!(Fr, "15")],
-                vec![field_new!(Fr, "16"), field_new!(Fr, "17"), field_new!(Fr, "18")]
+                vec![
+                    Fr::from_str("10").unwrap(),
+                    Fr::from_str("11").unwrap(),
+                    Fr::from_str("12").unwrap(),
+                ],
+                vec![
+                    Fr::from_str("13").unwrap(),
+                    Fr::from_str("14").unwrap(),
+                    Fr::from_str("15").unwrap(),
+                ],
+                vec![
+                    Fr::from_str("16").unwrap(),
+                    Fr::from_str("17").unwrap(),
+                    Fr::from_str("18").unwrap(),
+                ],
             ];
 
             let exp: Matrix<Fr> = vec![
-                vec![field_new!(Fr, "11"), field_new!(Fr, "13"), field_new!(Fr, "15")],
-                vec![field_new!(Fr, "17"), field_new!(Fr, "19"), field_new!(Fr, "21")],
-                vec![field_new!(Fr, "23"), field_new!(Fr, "25"), field_new!(Fr, "27")]
+                vec![
+                    Fr::from_str("11").unwrap(),
+                    Fr::from_str("13").unwrap(),
+                    Fr::from_str("15").unwrap(),
+                ],
+                vec![
+                    Fr::from_str("17").unwrap(),
+                    Fr::from_str("19").unwrap(),
+                    Fr::from_str("21").unwrap(),
+                ],
+                vec![
+                    Fr::from_str("23").unwrap(),
+                    Fr::from_str("25").unwrap(),
+                    Fr::from_str("27").unwrap(),
+                ],
             ];
             let lr: Matrix<Fr> = lhs.add(&rhs);
             let rl: Matrix<Fr> = rhs.add(&lhs);
@@ -2411,61 +2557,60 @@ mod tests {
 
         #[test]
         fn test_B1_matrix_add() {
-
             // 3 x 3 matrices
             let mut rng = test_rng();
             let g1gen = G1Projective::rand(&mut rng).into_affine();
             let lhs: Matrix<Com1<F>> = vec![
                 vec![
-                    Com1::<F>( G1Affine::zero(), g1gen ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "2") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "3") )
+                    Com1::<F>(G1Affine::zero(), g1gen),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "2")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "3")),
                 ],
                 vec![
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "4") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "5") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "6") )
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "4")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "5")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "6")),
                 ],
                 vec![
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "7") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "8") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "9") )
-                ]
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "7")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "8")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "9")),
+                ],
             ];
             let rhs: Matrix<Com1<F>> = vec![
                 vec![
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "10") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "11") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "12") )
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "10")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "11")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "12")),
                 ],
                 vec![
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "13") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "14") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "15") )
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "13")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "14")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "15")),
                 ],
                 vec![
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "16") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "17") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "18") )
-                ]
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "16")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "17")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "18")),
+                ],
             ];
 
             let exp: Matrix<Com1<F>> = vec![
                 vec![
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "11") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "13") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "15") )
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "11")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "13")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "15")),
                 ],
                 vec![
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "17") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "19") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "21") )
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "17")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "19")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "21")),
                 ],
                 vec![
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "23") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "25") ),
-                    Com1::<F>( G1Affine::zero(), affine_group_new!(g1gen, "27") )
-                ]
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "23")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "25")),
+                    Com1::<F>(G1Affine::zero(), affine_group_new!(g1gen, "27")),
+                ],
             ];
             let lr: Matrix<Com1<F>> = lhs.add(&rhs);
             let rl: Matrix<Com1<F>> = rhs.add(&lhs);
@@ -2481,61 +2626,60 @@ mod tests {
 
         #[test]
         fn test_B2_matrix_add() {
-
             // 3 x 3 matrices
             let mut rng = test_rng();
             let g2gen = G2Projective::rand(&mut rng).into_affine();
             let lhs: Matrix<Com2<F>> = vec![
                 vec![
-                    Com2::<F>( G2Affine::zero(), g2gen ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "2") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "3") )
+                    Com2::<F>(G2Affine::zero(), g2gen),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "2")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "3")),
                 ],
                 vec![
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "4") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "5") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "6") )
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "4")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "5")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "6")),
                 ],
                 vec![
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "7") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "8") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "9") )
-                ]
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "7")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "8")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "9")),
+                ],
             ];
             let rhs: Matrix<Com2<F>> = vec![
                 vec![
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "10") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "11") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "12") )
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "10")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "11")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "12")),
                 ],
                 vec![
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "13") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "14") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "15") )
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "13")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "14")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "15")),
                 ],
                 vec![
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "16") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "17") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "18") )
-                ]
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "16")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "17")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "18")),
+                ],
             ];
 
             let exp: Matrix<Com2<F>> = vec![
                 vec![
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "11") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "13") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "15") )
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "11")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "13")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "15")),
                 ],
                 vec![
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "17") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "19") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "21") )
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "17")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "19")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "21")),
                 ],
                 vec![
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "23") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "25") ),
-                    Com2::<F>( G2Affine::zero(), affine_group_new!(g2gen, "27") )
-                ]
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "23")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "25")),
+                    Com2::<F>(G2Affine::zero(), affine_group_new!(g2gen, "27")),
+                ],
             ];
             let lr: Matrix<Com2<F>> = lhs.add(&rhs);
             let rl: Matrix<Com2<F>> = rhs.add(&lhs);

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -11,7 +11,7 @@
 //!    1) Perfect soundness string (i.e. perfectly binding), or
 //!    2) Composable witness-indistinguishability string (i.e. perfectly hiding)
 
-use crate::data_structures::*;
+use crate::data_structures::{Com1, Com2};
 
 use ark_ec::{
     pairing::{Pairing, PairingOutput},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod data_structures;
 pub mod generator;
-pub mod statement;
 pub mod prover;
+pub mod statement;
 pub mod verifier;
 
 pub use crate::data_structures::*;

--- a/src/prover/commit.rs
+++ b/src/prover/commit.rs
@@ -5,8 +5,8 @@
 use ark_ec::pairing::Pairing;
 use ark_std::{fmt::Debug, rand::Rng, UniformRand};
 
-use crate::data_structures::*;
-use crate::generator::*;
+use crate::data_structures::{col_vec_to_vec, vec_to_col_vec, Com1, Com2, Mat, Matrix, B1, B2};
+use crate::generator::CRS;
 
 pub trait Commit: Eq + Debug {
     /// Append together two lists of commits to obtain single list of commits.
@@ -265,6 +265,8 @@ mod tests {
     use ark_ec::CurveGroup;
     use ark_ff::One;
     use ark_std::test_rng;
+
+    use crate::AbstractCrs;
 
     use super::*;
 

--- a/src/prover/commit.rs
+++ b/src/prover/commit.rs
@@ -74,7 +74,7 @@ where
 }
 
 /// Commit all [`G1`](ark_ec::Pairing::G1Affine) elements in list to corresponding element in [`B1`](crate::data_structures::Com1).
-pub fn batch_commit_G1<CR, E>(xvars: &Vec<E::G1Affine>, key: &CRS<E>, rng: &mut CR) -> Commit1<E>
+pub fn batch_commit_G1<CR, E>(xvars: &[E::G1Affine], key: &CRS<E>, rng: &mut CR) -> Commit1<E>
 where
     E: Pairing,
     CR: Rng,
@@ -122,7 +122,7 @@ where
 
 /// Commit all [scalar field](ark_ec::Pairing::Fr) elements in list to corresponding element in [`B1`](crate::data_structures::Com1).
 pub fn batch_commit_scalar_to_B1<CR, E>(
-    scalar_xvars: &Vec<E::ScalarField>,
+    scalar_xvars: &[E::ScalarField],
     key: &CRS<E>,
     rng: &mut CR,
 ) -> Commit1<E>
@@ -174,7 +174,7 @@ where
 }
 
 /// Commit all [`G2`](ark_ec::Pairing::G2Affine) elements in list to corresponding element in [`B2`](crate::data_structures::Com2).
-pub fn batch_commit_G2<CR, E>(yvars: &Vec<E::G2Affine>, key: &CRS<E>, rng: &mut CR) -> Commit2<E>
+pub fn batch_commit_G2<CR, E>(yvars: &[E::G2Affine], key: &CRS<E>, rng: &mut CR) -> Commit2<E>
 where
     E: Pairing,
     CR: Rng,
@@ -222,7 +222,7 @@ where
 
 /// Commit all [scalar field](ark_ec::Pairing::Fr) elements in list to corresponding element in [`B2`](crate::data_structures::Com2).
 pub fn batch_commit_scalar_to_B2<CR, E>(
-    scalar_yvars: &Vec<E::ScalarField>,
+    scalar_yvars: &[E::ScalarField],
     key: &CRS<E>,
     rng: &mut CR,
 ) -> Commit2<E>

--- a/src/prover/commit.rs
+++ b/src/prover/commit.rs
@@ -65,7 +65,7 @@ where
     // c := i_1(x) + r_1 u_1 + r_2 u_2
     Commit1::<E> {
         coms: vec![
-            Com1::<E>::linear_map(&xvar)
+            Com1::<E>::linear_map(xvar)
                 + vec_to_col_vec(&key.u)[0][0].scalar_mul(&r1)
                 + vec_to_col_vec(&key.u)[1][0].scalar_mul(&r2),
         ],
@@ -165,7 +165,7 @@ where
     // d := i_2(y) + s_1 v_1 + s_2 v_2
     Commit2::<E> {
         coms: vec![
-            Com2::<E>::linear_map(&yvar)
+            Com2::<E>::linear_map(yvar)
                 + vec_to_col_vec(&key.v)[0][0].scalar_mul(&s1)
                 + vec_to_col_vec(&key.v)[1][0].scalar_mul(&s2),
         ],

--- a/src/prover/prove.rs
+++ b/src/prover/prove.rs
@@ -25,8 +25,8 @@ pub trait Provable<E: Pairing, A1, A2, AT> {
     /// Commits to the witness variables and then produces a Groth-Sahai proof for this equation.
     fn commit_and_prove<CR>(
         &self,
-        xvars: &Vec<A1>,
-        yvars: &Vec<A2>,
+        xvars: &[A1],
+        yvars: &[A2],
         crs: &CRS<E>,
         rng: &mut CR,
     ) -> CProof<E>
@@ -35,8 +35,8 @@ pub trait Provable<E: Pairing, A1, A2, AT> {
     /// Produces a proof `(π, θ)` for this equation that the already-committed `x` and `y` variables will satisfy a single Groth-Sahai equation.
     fn prove<CR>(
         &self,
-        xvars: &Vec<A1>,
-        yvars: &Vec<A2>,
+        xvars: &[A1],
+        yvars: &[A2],
         xcoms: &Commit1<E>,
         ycoms: &Commit2<E>,
         crs: &CRS<E>,
@@ -66,8 +66,8 @@ pub struct CProof<E: Pairing> {
 impl<E: Pairing> Provable<E, E::G1Affine, E::G2Affine, E::TargetField> for PPE<E> {
     fn commit_and_prove<CR>(
         &self,
-        xvars: &Vec<E::G1Affine>,
-        yvars: &Vec<E::G2Affine>,
+        xvars: &[E::G1Affine],
+        yvars: &[E::G2Affine],
         crs: &CRS<E>,
         rng: &mut CR,
     ) -> CProof<E>
@@ -86,8 +86,8 @@ impl<E: Pairing> Provable<E, E::G1Affine, E::G2Affine, E::TargetField> for PPE<E
 
     fn prove<CR>(
         &self,
-        xvars: &Vec<E::G1Affine>,
-        yvars: &Vec<E::G2Affine>,
+        xvars: &[E::G1Affine],
+        yvars: &[E::G2Affine],
         xcoms: &Commit1<E>,
         ycoms: &Commit2<E>,
         crs: &CRS<E>,
@@ -169,8 +169,8 @@ impl<E: Pairing> Provable<E, E::G1Affine, E::G2Affine, E::TargetField> for PPE<E
 impl<E: Pairing> Provable<E, E::G1Affine, E::ScalarField, E::G1Affine> for MSMEG1<E> {
     fn commit_and_prove<CR>(
         &self,
-        xvars: &Vec<E::G1Affine>,
-        scalar_yvars: &Vec<E::ScalarField>,
+        xvars: &[E::G1Affine],
+        scalar_yvars: &[E::ScalarField],
         crs: &CRS<E>,
         rng: &mut CR,
     ) -> CProof<E>
@@ -189,8 +189,8 @@ impl<E: Pairing> Provable<E, E::G1Affine, E::ScalarField, E::G1Affine> for MSMEG
 
     fn prove<CR>(
         &self,
-        xvars: &Vec<E::G1Affine>,
-        scalar_yvars: &Vec<E::ScalarField>,
+        xvars: &[E::G1Affine],
+        scalar_yvars: &[E::ScalarField],
         xcoms: &Commit1<E>,
         scalar_ycoms: &Commit2<E>,
         crs: &CRS<E>,
@@ -272,8 +272,8 @@ impl<E: Pairing> Provable<E, E::G1Affine, E::ScalarField, E::G1Affine> for MSMEG
 impl<E: Pairing> Provable<E, E::ScalarField, E::G2Affine, E::G2Affine> for MSMEG2<E> {
     fn commit_and_prove<CR>(
         &self,
-        scalar_xvars: &Vec<E::ScalarField>,
-        yvars: &Vec<E::G2Affine>,
+        scalar_xvars: &[E::ScalarField],
+        yvars: &[E::G2Affine],
         crs: &CRS<E>,
         rng: &mut CR,
     ) -> CProof<E>
@@ -292,8 +292,8 @@ impl<E: Pairing> Provable<E, E::ScalarField, E::G2Affine, E::G2Affine> for MSMEG
 
     fn prove<CR>(
         &self,
-        scalar_xvars: &Vec<E::ScalarField>,
-        yvars: &Vec<E::G2Affine>,
+        scalar_xvars: &[E::ScalarField],
+        yvars: &[E::G2Affine],
         scalar_xcoms: &Commit1<E>,
         ycoms: &Commit2<E>,
         crs: &CRS<E>,
@@ -377,8 +377,8 @@ impl<E: Pairing> Provable<E, E::ScalarField, E::G2Affine, E::G2Affine> for MSMEG
 impl<E: Pairing> Provable<E, E::ScalarField, E::ScalarField, E::ScalarField> for QuadEqu<E> {
     fn commit_and_prove<CR>(
         &self,
-        scalar_xvars: &Vec<E::ScalarField>,
-        scalar_yvars: &Vec<E::ScalarField>,
+        scalar_xvars: &[E::ScalarField],
+        scalar_yvars: &[E::ScalarField],
         crs: &CRS<E>,
         rng: &mut CR,
     ) -> CProof<E>
@@ -403,8 +403,8 @@ impl<E: Pairing> Provable<E, E::ScalarField, E::ScalarField, E::ScalarField> for
     }
     fn prove<CR>(
         &self,
-        scalar_xvars: &Vec<E::ScalarField>,
-        scalar_yvars: &Vec<E::ScalarField>,
+        scalar_xvars: &[E::ScalarField],
+        scalar_yvars: &[E::ScalarField],
         scalar_xcoms: &Commit1<E>,
         scalar_ycoms: &Commit2<E>,
         crs: &CRS<E>,

--- a/src/prover/prove.rs
+++ b/src/prover/prove.rs
@@ -3,62 +3,76 @@
 //! Abstractly, a proof for an equation for the SXDH instantiation of Groth-Sahai consists of the following values,
 //! with respect to a pre-defined bilinear group `(A1, A2, AT)`:
 //!
-//! - `π`: 1-2 elements in [`B2`](crate::data_structures::Com2) (equiv. 2-4 elements in [`G2`](ark_ec::PairingEngine::G2Affine))
+//! - `π`: 1-2 elements in [`B2`](crate::data_structures::Com2) (equiv. 2-4 elements in [`G2`](ark_ec::Pairing::G2Affine))
 //!     which prove about the satisfiability of `A2` variables in the equation, and
-//! - `θ`: 1-2 elements in [`B1`](crate::data_structures::Com1) (equiv. 2-4 elements in [`G1`](ark_ec::PairingEngine::G1Affine))
+//! - `θ`: 1-2 elements in [`B1`](crate::data_structures::Com1) (equiv. 2-4 elements in [`G1`](ark_ec::Pairing::G1Affine))
 //!     which prove about the satisfiability of `A1` variables in the equation
 //!
-//! Computing these proofs primarily involves matrix multiplication in the [scalar field](ark_ec::PairingEngine::Fr) and in `B1` and `B2`.
+//! Computing these proofs primarily involves matrix multiplication in the [scalar field](ark_ec::Pairing::Fr) and in `B1` and `B2`.
 //!
 //! See the [`statement`](crate::statement) module for more details about the structure of the equations being proven about.
 
-use ark_ec::PairingEngine;
-use ark_std::{
-    UniformRand,
-    rand::{CryptoRng, Rng}
-};
+use ark_ec::pairing::Pairing;
+use ark_std::{rand::Rng, UniformRand};
 
+use super::commit::*;
 use crate::data_structures::*;
 use crate::generator::*;
 use crate::statement::*;
-use super::commit::*;
-
 
 /// A collection  of attributes containing prover functionality for an [`Equation`](crate::statement::Equation).
-pub trait Provable<E: PairingEngine, A1, A2, AT> {
-
+pub trait Provable<E: Pairing, A1, A2, AT> {
     /// Commits to the witness variables and then produces a Groth-Sahai proof for this equation.
-    fn commit_and_prove<CR>(&self, xvars: &Vec<A1>, yvars: &Vec<A2>, crs: &CRS<E>, rng: &mut CR) -> CProof<E>
-        where
-            CR: Rng + CryptoRng;
+    fn commit_and_prove<CR>(
+        &self,
+        xvars: &Vec<A1>,
+        yvars: &Vec<A2>,
+        crs: &CRS<E>,
+        rng: &mut CR,
+    ) -> CProof<E>
+    where
+        CR: Rng;
     /// Produces a proof `(π, θ)` for this equation that the already-committed `x` and `y` variables will satisfy a single Groth-Sahai equation.
-    fn prove<CR>(&self, xvars: &Vec<A1>, yvars: &Vec<A2>, xcoms: &Commit1<E>, ycoms: &Commit2<E>, crs: &CRS<E>, rng: &mut CR) -> EquProof<E>
-        where
-            CR: Rng + CryptoRng;
+    fn prove<CR>(
+        &self,
+        xvars: &Vec<A1>,
+        yvars: &Vec<A2>,
+        xcoms: &Commit1<E>,
+        ycoms: &Commit2<E>,
+        crs: &CRS<E>,
+        rng: &mut CR,
+    ) -> EquProof<E>
+    where
+        CR: Rng;
 }
 
 /// A witness-indistinguishable proof for a single [`Equation`](crate::statement::Equation).
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct EquProof<E: PairingEngine> {
+pub struct EquProof<E: Pairing> {
     pub pi: Vec<Com2<E>>,
     pub theta: Vec<Com1<E>>,
     pub equ_type: EquType,
-    rand: Matrix<E::Fr>,
+    rand: Matrix<E::ScalarField>,
 }
 
 /// A collection of committed variables and proofs for Groth-Sahai compatible bilinear equations.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct CProof<E: PairingEngine> {
+pub struct CProof<E: Pairing> {
     pub xcoms: Commit1<E>,
     pub ycoms: Commit2<E>,
     pub equ_proofs: Vec<EquProof<E>>,
 }
 
-impl<E: PairingEngine> Provable<E, E::G1Affine, E::G2Affine, E::Fqk> for PPE<E> {
-
-    fn commit_and_prove<CR>(&self, xvars: &Vec<E::G1Affine>, yvars: &Vec<E::G2Affine>, crs: &CRS<E>, rng: &mut CR) -> CProof<E>
+impl<E: Pairing> Provable<E, E::G1Affine, E::G2Affine, E::TargetField> for PPE<E> {
+    fn commit_and_prove<CR>(
+        &self,
+        xvars: &Vec<E::G1Affine>,
+        yvars: &Vec<E::G2Affine>,
+        crs: &CRS<E>,
+        rng: &mut CR,
+    ) -> CProof<E>
     where
-        CR: Rng + CryptoRng
+        CR: Rng,
     {
         let xcoms: Commit1<E> = batch_commit_G1(&xvars, crs, rng);
         let ycoms: Commit2<E> = batch_commit_G2(&yvars, crs, rng);
@@ -70,9 +84,17 @@ impl<E: PairingEngine> Provable<E, E::G1Affine, E::G2Affine, E::Fqk> for PPE<E> 
         }
     }
 
-    fn prove<CR>(&self, xvars: &Vec<E::G1Affine>, yvars: &Vec<E::G2Affine>, xcoms: &Commit1<E>, ycoms: &Commit2<E>, crs: &CRS<E>, rng: &mut CR) -> EquProof<E>
+    fn prove<CR>(
+        &self,
+        xvars: &Vec<E::G1Affine>,
+        yvars: &Vec<E::G2Affine>,
+        xcoms: &Commit1<E>,
+        ycoms: &Commit2<E>,
+        crs: &CRS<E>,
+        rng: &mut CR,
+    ) -> EquProof<E>
     where
-        CR: Rng + CryptoRng
+        CR: Rng,
     {
         // Gamma is an (m x n) matrix with m x variables and n y variables
         // x's commit randomness (i.e. R) is a (m x 2) matrix
@@ -93,21 +115,26 @@ impl<E: PairingEngine> Provable<E, E::G1Affine, E::G2Affine, E::Fqk> for PPE<E> 
         // (2 x n) field matrix S^T, in GS parlance
         let y_rand_trans = ycoms.rand.transpose();
         // (2 x 2) field matrix T, in GS parlance
-        let pf_rand: Matrix<E::Fr> = vec![
-            vec![ E::Fr::rand(rng), E::Fr::rand(rng) ],
-            vec![ E::Fr::rand(rng), E::Fr::rand(rng) ]
+        let pf_rand: Matrix<E::ScalarField> = vec![
+            vec![E::ScalarField::rand(rng), E::ScalarField::rand(rng)],
+            vec![E::ScalarField::rand(rng), E::ScalarField::rand(rng)],
         ];
 
         // (2 x 1) Com2 matrix
-        let x_rand_lin_b = vec_to_col_vec(&Com2::<E>::batch_linear_map(&self.b_consts)).left_mul(&x_rand_trans, is_parallel);
+        let x_rand_lin_b = vec_to_col_vec(&Com2::<E>::batch_linear_map(&self.b_consts))
+            .left_mul(&x_rand_trans, is_parallel);
 
         // (2 x n) field matrix
         let x_rand_stmt = x_rand_trans.right_mul(&self.gamma, is_parallel);
         // (2 x 1) Com2 matrix
-        let x_rand_stmt_lin_y = vec_to_col_vec(&Com2::<E>::batch_linear_map(&yvars)).left_mul(&x_rand_stmt, is_parallel);
+        let x_rand_stmt_lin_y = vec_to_col_vec(&Com2::<E>::batch_linear_map(&yvars))
+            .left_mul(&x_rand_stmt, is_parallel);
 
         // (2 x 2) field matrix
-        let pf_rand_stmt = x_rand_trans.right_mul(&self.gamma, is_parallel).right_mul(&ycoms.rand, is_parallel).add(&pf_rand.transpose().neg());
+        let pf_rand_stmt = x_rand_trans
+            .right_mul(&self.gamma, is_parallel)
+            .right_mul(&ycoms.rand, is_parallel)
+            .add(&pf_rand.transpose().neg());
         // (2 x 1) Com2 matrix
         let pf_rand_stmt_com2 = vec_to_col_vec(&crs.v).left_mul(&pf_rand_stmt, is_parallel);
 
@@ -115,12 +142,14 @@ impl<E: PairingEngine> Provable<E, E::G1Affine, E::G2Affine, E::Fqk> for PPE<E> 
         assert_eq!(pi.len(), 2);
 
         // (2 x 1) Com1 matrix
-        let y_rand_lin_a = vec_to_col_vec(&Com1::<E>::batch_linear_map(&self.a_consts)).left_mul(&y_rand_trans, is_parallel);
+        let y_rand_lin_a = vec_to_col_vec(&Com1::<E>::batch_linear_map(&self.a_consts))
+            .left_mul(&y_rand_trans, is_parallel);
 
         // (2 x m) field matrix
         let y_rand_stmt = y_rand_trans.right_mul(&self.gamma.transpose(), is_parallel);
         // (2 x 1) Com1 matrix
-        let y_rand_stmt_lin_x = vec_to_col_vec(&Com1::<E>::batch_linear_map(&xvars)).left_mul(&y_rand_stmt, is_parallel);
+        let y_rand_stmt_lin_x = vec_to_col_vec(&Com1::<E>::batch_linear_map(&xvars))
+            .left_mul(&y_rand_stmt, is_parallel);
 
         // (2 x 1) Com1 matrix
         let pf_rand_com1 = vec_to_col_vec(&crs.u).left_mul(&pf_rand, is_parallel);
@@ -132,17 +161,21 @@ impl<E: PairingEngine> Provable<E, E::G1Affine, E::G2Affine, E::Fqk> for PPE<E> 
             pi,
             theta,
             equ_type: EquType::PairingProduct,
-            rand: pf_rand
+            rand: pf_rand,
         }
     }
 }
 
-
-impl<E: PairingEngine> Provable<E, E::G1Affine, E::Fr, E::G1Affine> for MSMEG1<E> {
-
-    fn commit_and_prove<CR>(&self, xvars: &Vec<E::G1Affine>, scalar_yvars: &Vec<E::Fr>, crs: &CRS<E>, rng: &mut CR) -> CProof<E>
+impl<E: Pairing> Provable<E, E::G1Affine, E::ScalarField, E::G1Affine> for MSMEG1<E> {
+    fn commit_and_prove<CR>(
+        &self,
+        xvars: &Vec<E::G1Affine>,
+        scalar_yvars: &Vec<E::ScalarField>,
+        crs: &CRS<E>,
+        rng: &mut CR,
+    ) -> CProof<E>
     where
-        CR: Rng + CryptoRng
+        CR: Rng,
     {
         let xcoms: Commit1<E> = batch_commit_G1(&xvars, crs, rng);
         let scalar_ycoms: Commit2<E> = batch_commit_scalar_to_B2(&scalar_yvars, crs, rng);
@@ -154,9 +187,17 @@ impl<E: PairingEngine> Provable<E, E::G1Affine, E::Fr, E::G1Affine> for MSMEG1<E
         }
     }
 
-    fn prove<CR>(&self, xvars: &Vec<E::G1Affine>, scalar_yvars: &Vec<E::Fr>, xcoms: &Commit1<E>, scalar_ycoms: &Commit2<E>, crs: &CRS<E>, rng: &mut CR) -> EquProof<E>
+    fn prove<CR>(
+        &self,
+        xvars: &Vec<E::G1Affine>,
+        scalar_yvars: &Vec<E::ScalarField>,
+        xcoms: &Commit1<E>,
+        scalar_ycoms: &Commit2<E>,
+        crs: &CRS<E>,
+        rng: &mut CR,
+    ) -> EquProof<E>
     where
-        CR: Rng + CryptoRng
+        CR: Rng,
     {
         // Gamma is an (m x n') matrix with m x variables and n' scalar y variables
         // x's commit randomness (i.e. R) is a (m x 2) matrix
@@ -177,20 +218,26 @@ impl<E: PairingEngine> Provable<E, E::G1Affine, E::Fr, E::G1Affine> for MSMEG1<E
         // (1 x n') field matrix s^T, in GS parlance
         let y_rand_trans = scalar_ycoms.rand.transpose();
         // (1 x 2) field matrix T, in GS parlance
-        let pf_rand: Matrix<E::Fr> = vec![
-            vec![ E::Fr::rand(rng), E::Fr::rand(rng) ],
-        ];
+        let pf_rand: Matrix<E::ScalarField> =
+            vec![vec![E::ScalarField::rand(rng), E::ScalarField::rand(rng)]];
 
         // (2 x 1) Com2 matrix
-        let x_rand_lin_b = vec_to_col_vec(&Com2::<E>::batch_scalar_linear_map(&self.b_consts, &crs)).left_mul(&x_rand_trans, is_parallel);
+        let x_rand_lin_b =
+            vec_to_col_vec(&Com2::<E>::batch_scalar_linear_map(&self.b_consts, &crs))
+                .left_mul(&x_rand_trans, is_parallel);
 
         // (2 x n) field matrix
         let x_rand_stmt = x_rand_trans.right_mul(&self.gamma, is_parallel);
         // (2 x 1) Com2 matrix
-        let x_rand_stmt_lin_y = vec_to_col_vec(&Com2::<E>::batch_scalar_linear_map(&scalar_yvars, &crs)).left_mul(&x_rand_stmt, is_parallel);
+        let x_rand_stmt_lin_y =
+            vec_to_col_vec(&Com2::<E>::batch_scalar_linear_map(&scalar_yvars, &crs))
+                .left_mul(&x_rand_stmt, is_parallel);
 
         // (2 x 1) field matrix
-        let pf_rand_stmt = x_rand_trans.right_mul(&self.gamma, is_parallel).right_mul(&scalar_ycoms.rand, is_parallel).add(&pf_rand.transpose().neg());
+        let pf_rand_stmt = x_rand_trans
+            .right_mul(&self.gamma, is_parallel)
+            .right_mul(&scalar_ycoms.rand, is_parallel)
+            .add(&pf_rand.transpose().neg());
         // (2 x 1) Com2 matrix
         let v1: Matrix<Com2<E>> = vec![vec![crs.v[0]]];
         let pf_rand_stmt_com2 = v1.left_mul(&pf_rand_stmt, is_parallel);
@@ -199,12 +246,14 @@ impl<E: PairingEngine> Provable<E, E::G1Affine, E::Fr, E::G1Affine> for MSMEG1<E
         assert_eq!(pi.len(), 2);
 
         // (1 x 1) Com1 matrix
-        let y_rand_lin_a = vec_to_col_vec(&Com1::<E>::batch_linear_map(&self.a_consts)).left_mul(&y_rand_trans, is_parallel);
+        let y_rand_lin_a = vec_to_col_vec(&Com1::<E>::batch_linear_map(&self.a_consts))
+            .left_mul(&y_rand_trans, is_parallel);
 
         // (1 x m) field matrix
         let y_rand_stmt = y_rand_trans.right_mul(&self.gamma.transpose(), is_parallel);
         // (1 x 1) Com1 matrix
-        let y_rand_stmt_lin_x = vec_to_col_vec(&Com1::<E>::batch_linear_map(&xvars)).left_mul(&y_rand_stmt, is_parallel);
+        let y_rand_stmt_lin_x = vec_to_col_vec(&Com1::<E>::batch_linear_map(&xvars))
+            .left_mul(&y_rand_stmt, is_parallel);
 
         // (1 x 1) Com1 matrix
         let pf_rand_com1 = vec_to_col_vec(&crs.u).left_mul(&pf_rand, is_parallel);
@@ -216,16 +265,21 @@ impl<E: PairingEngine> Provable<E, E::G1Affine, E::Fr, E::G1Affine> for MSMEG1<E
             pi,
             theta,
             equ_type: EquType::MultiScalarG1,
-            rand: pf_rand
+            rand: pf_rand,
         }
     }
 }
 
-impl<E: PairingEngine> Provable<E, E::Fr, E::G2Affine, E::G2Affine> for MSMEG2<E> {
-
-    fn commit_and_prove<CR>(&self, scalar_xvars: &Vec<E::Fr>, yvars: &Vec<E::G2Affine>, crs: &CRS<E>, rng: &mut CR) -> CProof<E>
+impl<E: Pairing> Provable<E, E::ScalarField, E::G2Affine, E::G2Affine> for MSMEG2<E> {
+    fn commit_and_prove<CR>(
+        &self,
+        scalar_xvars: &Vec<E::ScalarField>,
+        yvars: &Vec<E::G2Affine>,
+        crs: &CRS<E>,
+        rng: &mut CR,
+    ) -> CProof<E>
     where
-        CR: Rng + CryptoRng
+        CR: Rng,
     {
         let scalar_xcoms: Commit1<E> = batch_commit_scalar_to_B1(&scalar_xvars, crs, rng);
         let ycoms: Commit2<E> = batch_commit_G2(&yvars, crs, rng);
@@ -237,9 +291,17 @@ impl<E: PairingEngine> Provable<E, E::Fr, E::G2Affine, E::G2Affine> for MSMEG2<E
         }
     }
 
-    fn prove<CR>(&self, scalar_xvars: &Vec<E::Fr>, yvars: &Vec<E::G2Affine>, scalar_xcoms: &Commit1<E>, ycoms: &Commit2<E>, crs: &CRS<E>, rng: &mut CR) -> EquProof<E>
+    fn prove<CR>(
+        &self,
+        scalar_xvars: &Vec<E::ScalarField>,
+        yvars: &Vec<E::G2Affine>,
+        scalar_xcoms: &Commit1<E>,
+        ycoms: &Commit2<E>,
+        crs: &CRS<E>,
+        rng: &mut CR,
+    ) -> EquProof<E>
     where
-        CR: Rng + CryptoRng
+        CR: Rng,
     {
         // Gamma is an (m' x n) matrix with m' x variables and n y variables
         // x's commit randomness (i.e. r) is a (m' x 1) matrix (i.e. column vector)
@@ -260,21 +322,26 @@ impl<E: PairingEngine> Provable<E, E::Fr, E::G2Affine, E::G2Affine> for MSMEG2<E
         // (2 x n) field matrix S^T, in GS parlance
         let y_rand_trans = ycoms.rand.transpose();
         // (2 x 1) field matrix T, in GS parlance
-        let pf_rand: Matrix<E::Fr> = vec![
-            vec![ E::Fr::rand(rng) ],
-            vec![ E::Fr::rand(rng) ]
+        let pf_rand: Matrix<E::ScalarField> = vec![
+            vec![E::ScalarField::rand(rng)],
+            vec![E::ScalarField::rand(rng)],
         ];
 
         // (1 x 1) Com2 matrix
-        let x_rand_lin_b = vec_to_col_vec(&Com2::<E>::batch_linear_map(&self.b_consts)).left_mul(&x_rand_trans, is_parallel);
+        let x_rand_lin_b = vec_to_col_vec(&Com2::<E>::batch_linear_map(&self.b_consts))
+            .left_mul(&x_rand_trans, is_parallel);
 
         // (1 x n) field matrix
         let x_rand_stmt = x_rand_trans.right_mul(&self.gamma, is_parallel);
         // (1 x 1) Com2 matrix
-        let x_rand_stmt_lin_y = vec_to_col_vec(&Com2::<E>::batch_linear_map(&yvars)).left_mul(&x_rand_stmt, is_parallel);
+        let x_rand_stmt_lin_y = vec_to_col_vec(&Com2::<E>::batch_linear_map(&yvars))
+            .left_mul(&x_rand_stmt, is_parallel);
 
         // (1 x 2) field matrix
-        let pf_rand_stmt = x_rand_trans.right_mul(&self.gamma, is_parallel).right_mul(&ycoms.rand, is_parallel).add(&pf_rand.transpose().neg());
+        let pf_rand_stmt = x_rand_trans
+            .right_mul(&self.gamma, is_parallel)
+            .right_mul(&ycoms.rand, is_parallel)
+            .add(&pf_rand.transpose().neg());
         // (1 x 1) Com2 matrix
         let pf_rand_stmt_com2 = vec_to_col_vec(&crs.v).left_mul(&pf_rand_stmt, is_parallel);
 
@@ -282,12 +349,16 @@ impl<E: PairingEngine> Provable<E, E::Fr, E::G2Affine, E::G2Affine> for MSMEG2<E
         assert_eq!(pi.len(), 1);
 
         // (2 x 1) Com1 matrix
-        let y_rand_lin_a = vec_to_col_vec(&Com1::<E>::batch_scalar_linear_map(&self.a_consts, &crs)).left_mul(&y_rand_trans, is_parallel);
+        let y_rand_lin_a =
+            vec_to_col_vec(&Com1::<E>::batch_scalar_linear_map(&self.a_consts, &crs))
+                .left_mul(&y_rand_trans, is_parallel);
 
         // (2 x m') field matrix
         let y_rand_stmt = y_rand_trans.right_mul(&self.gamma.transpose(), is_parallel);
         // (2 x 1) Com1 matrix
-        let y_rand_stmt_lin_x = vec_to_col_vec(&Com1::<E>::batch_scalar_linear_map(&scalar_xvars, &crs)).left_mul(&y_rand_stmt, is_parallel);
+        let y_rand_stmt_lin_x =
+            vec_to_col_vec(&Com1::<E>::batch_scalar_linear_map(&scalar_xvars, &crs))
+                .left_mul(&y_rand_stmt, is_parallel);
 
         // (2 x 1) Com1 matrix
         let u1: Matrix<Com1<E>> = vec![vec![crs.u[0]]];
@@ -300,16 +371,21 @@ impl<E: PairingEngine> Provable<E, E::Fr, E::G2Affine, E::G2Affine> for MSMEG2<E
             pi,
             theta,
             equ_type: EquType::MultiScalarG2,
-            rand: pf_rand
+            rand: pf_rand,
         }
     }
 }
 
-impl<E: PairingEngine> Provable<E, E::Fr, E::Fr, E::Fr> for QuadEqu<E> {
-
-    fn commit_and_prove<CR>(&self, scalar_xvars: &Vec<E::Fr>, scalar_yvars: &Vec<E::Fr>, crs: &CRS<E>, rng: &mut CR) -> CProof<E>
+impl<E: Pairing> Provable<E, E::ScalarField, E::ScalarField, E::ScalarField> for QuadEqu<E> {
+    fn commit_and_prove<CR>(
+        &self,
+        scalar_xvars: &Vec<E::ScalarField>,
+        scalar_yvars: &Vec<E::ScalarField>,
+        crs: &CRS<E>,
+        rng: &mut CR,
+    ) -> CProof<E>
     where
-        CR: Rng + CryptoRng
+        CR: Rng,
     {
         let scalar_xcoms: Commit1<E> = batch_commit_scalar_to_B1(&scalar_xvars, crs, rng);
         let scalar_ycoms: Commit2<E> = batch_commit_scalar_to_B2(&scalar_yvars, crs, rng);
@@ -317,12 +393,27 @@ impl<E: PairingEngine> Provable<E, E::Fr, E::Fr, E::Fr> for QuadEqu<E> {
         CProof::<E> {
             xcoms: scalar_xcoms.clone(),
             ycoms: scalar_ycoms.clone(),
-            equ_proofs: vec![self.prove(scalar_xvars, scalar_yvars, &scalar_xcoms, &scalar_ycoms, crs, rng)],
+            equ_proofs: vec![self.prove(
+                scalar_xvars,
+                scalar_yvars,
+                &scalar_xcoms,
+                &scalar_ycoms,
+                crs,
+                rng,
+            )],
         }
     }
-    fn prove<CR>(&self, scalar_xvars: &Vec<E::Fr>, scalar_yvars: &Vec<E::Fr>, scalar_xcoms: &Commit1<E>, scalar_ycoms: &Commit2<E>, crs: &CRS<E>, rng: &mut CR) -> EquProof<E>
+    fn prove<CR>(
+        &self,
+        scalar_xvars: &Vec<E::ScalarField>,
+        scalar_yvars: &Vec<E::ScalarField>,
+        scalar_xcoms: &Commit1<E>,
+        scalar_ycoms: &Commit2<E>,
+        crs: &CRS<E>,
+        rng: &mut CR,
+    ) -> EquProof<E>
     where
-        CR: Rng + CryptoRng
+        CR: Rng,
     {
         // Gamma is an (m' x n') matrix with m' x variables and n' y variables
         // x's commit randomness (i.e. r) is a (m' x 1) matrix (i.e. column vector)
@@ -343,17 +434,24 @@ impl<E: PairingEngine> Provable<E, E::Fr, E::Fr, E::Fr> for QuadEqu<E> {
         // (1 x n') field matrix s^T, in GS parlance
         let y_rand_trans = scalar_ycoms.rand.transpose();
         // field element T, in GS parlance
-        let pf_rand: Matrix<E::Fr> = vec![vec![E::Fr::rand(rng)]];
+        let pf_rand: Matrix<E::ScalarField> = vec![vec![E::ScalarField::rand(rng)]];
 
-        let x_rand_lin_b = vec_to_col_vec(&Com2::<E>::batch_scalar_linear_map(&self.b_consts, &crs)).left_mul(&x_rand_trans, is_parallel);
+        let x_rand_lin_b =
+            vec_to_col_vec(&Com2::<E>::batch_scalar_linear_map(&self.b_consts, &crs))
+                .left_mul(&x_rand_trans, is_parallel);
 
         // (1 x n') field matrix
         let x_rand_stmt = x_rand_trans.right_mul(&self.gamma, is_parallel);
         // (1 x 1) Com2 matrix
-        let x_rand_stmt_lin_y = vec_to_col_vec(&Com2::<E>::batch_scalar_linear_map(&scalar_yvars, &crs)).left_mul(&x_rand_stmt, is_parallel);
+        let x_rand_stmt_lin_y =
+            vec_to_col_vec(&Com2::<E>::batch_scalar_linear_map(&scalar_yvars, &crs))
+                .left_mul(&x_rand_stmt, is_parallel);
 
         // (1 x 2) field matrix
-        let pf_rand_stmt = x_rand_trans.right_mul(&self.gamma, is_parallel).right_mul(&scalar_ycoms.rand, is_parallel).add(&pf_rand.transpose().neg());
+        let pf_rand_stmt = x_rand_trans
+            .right_mul(&self.gamma, is_parallel)
+            .right_mul(&scalar_ycoms.rand, is_parallel)
+            .add(&pf_rand.transpose().neg());
         let v1: Matrix<Com2<E>> = vec![vec![crs.v[0]]];
         // (1 x 1) Com2 matrix
         let pf_rand_stmt_com2 = v1.left_mul(&pf_rand_stmt, is_parallel);
@@ -362,12 +460,16 @@ impl<E: PairingEngine> Provable<E, E::Fr, E::Fr, E::Fr> for QuadEqu<E> {
         assert_eq!(pi.len(), 1);
 
         // (1 x 1) Com1 matrix
-        let y_rand_lin_a = vec_to_col_vec(&Com1::<E>::batch_scalar_linear_map(&self.a_consts, &crs)).left_mul(&y_rand_trans, is_parallel);
+        let y_rand_lin_a =
+            vec_to_col_vec(&Com1::<E>::batch_scalar_linear_map(&self.a_consts, &crs))
+                .left_mul(&y_rand_trans, is_parallel);
 
         // (1 x m') field matrix
         let y_rand_stmt = y_rand_trans.right_mul(&self.gamma.transpose(), is_parallel);
         // (1 x 1) Com1 matrix
-        let y_rand_stmt_lin_x = vec_to_col_vec(&Com1::<E>::batch_scalar_linear_map(&scalar_xvars, &crs)).left_mul(&y_rand_stmt, is_parallel);
+        let y_rand_stmt_lin_x =
+            vec_to_col_vec(&Com1::<E>::batch_scalar_linear_map(&scalar_xvars, &crs))
+                .left_mul(&y_rand_stmt, is_parallel);
 
         // (1 x 1) Com1 matrix
         let u1: Matrix<Com1<E>> = vec![vec![crs.u[0]]];
@@ -380,7 +482,7 @@ impl<E: PairingEngine> Provable<E, E::Fr, E::Fr, E::Fr> for QuadEqu<E> {
             pi,
             theta,
             equ_type: EquType::Quadratic,
-            rand: pf_rand
+            rand: pf_rand,
         }
     }
 }
@@ -389,39 +491,40 @@ impl<E: PairingEngine> Provable<E, E::Fr, E::Fr, E::Fr> for QuadEqu<E> {
 mod tests {
     #![allow(non_snake_case)]
 
-    use ark_bls12_381::{Bls12_381 as F};
-    use ark_ec::{PairingEngine, AffineCurve, ProjectiveCurve};
-    use ark_ff::{UniformRand, Zero, One};
+    use ark_bls12_381::Bls12_381 as F;
+    use ark_ec::CurveGroup;
+    use ark_ff::{One, UniformRand, Zero};
+    use ark_std::ops::Mul;
     use ark_std::test_rng;
 
     use super::*;
 
-    type G1Affine = <F as PairingEngine>::G1Affine;
-    type G2Affine = <F as PairingEngine>::G2Affine;
-    type Fr = <F as PairingEngine>::Fr;
-    type Fqk = <F as PairingEngine>::Fqk;
+    type G1Affine = <F as Pairing>::G1Affine;
+    type G2Affine = <F as Pairing>::G2Affine;
+    type Fr = <F as Pairing>::ScalarField;
+    type Fqk = <F as Pairing>::TargetField;
 
     #[test]
     fn test_PPE_proof_type() {
-
         let mut rng = test_rng();
         let crs = CRS::<F>::generate_crs(&mut rng);
 
         let xvars: Vec<G1Affine> = vec![
             crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine(),
-            crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine()
+            crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine(),
         ];
-        let yvars: Vec<G2Affine> = vec![
-            crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine()
-        ];
+        let yvars: Vec<G2Affine> = vec![crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine()];
         let xcoms: Commit1<F> = batch_commit_G1(&xvars, &crs, &mut rng);
         let ycoms: Commit2<F> = batch_commit_G2(&yvars, &crs, &mut rng);
 
         let equ: PPE<F> = PPE::<F> {
             a_consts: vec![crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine()],
-            b_consts: vec![crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine(), crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine()],
+            b_consts: vec![
+                crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine(),
+                crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine(),
+            ],
             gamma: vec![vec![Fr::one()], vec![Fr::zero()]],
-            target: Fqk::rand(&mut rng)
+            target: Fqk::rand(&mut rng),
         };
         let proof: EquProof<F> = equ.prove(&xvars, &yvars, &xcoms, &ycoms, &crs, &mut rng);
 
@@ -430,7 +533,6 @@ mod tests {
 
     #[test]
     fn test_PPE_cproof_is_commit_and_prove() {
-
         std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
         let mut rng = test_rng();
         let mut rng2 = test_rng();
@@ -438,16 +540,17 @@ mod tests {
 
         let xvars: Vec<G1Affine> = vec![
             crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine(),
-            crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine()
+            crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine(),
         ];
-        let yvars: Vec<G2Affine> = vec![
-            crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine()
-        ];
+        let yvars: Vec<G2Affine> = vec![crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine()];
         let equ: PPE<F> = PPE::<F> {
             a_consts: vec![crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine()],
-            b_consts: vec![crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine(), crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine()],
+            b_consts: vec![
+                crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine(),
+                crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine(),
+            ],
             gamma: vec![vec![Fr::one()], vec![Fr::zero()]],
-            target: Fqk::rand(&mut rng)
+            target: Fqk::rand(&mut rng),
         };
 
         // Individually commit then prove
@@ -484,17 +587,14 @@ mod tests {
 
     #[test]
     fn test_MSMEG1_proof_type() {
-
         let mut rng = test_rng();
         let crs = CRS::<F>::generate_crs(&mut rng);
 
         let xvars: Vec<G1Affine> = vec![
             crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine(),
-            crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine()
+            crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine(),
         ];
-        let scalar_yvars: Vec<Fr> = vec![
-            Fr::rand(&mut rng)
-        ];
+        let scalar_yvars: Vec<Fr> = vec![Fr::rand(&mut rng)];
         let xcoms: Commit1<F> = batch_commit_G1(&xvars, &crs, &mut rng);
         let scalar_ycoms: Commit2<F> = batch_commit_scalar_to_B2(&scalar_yvars, &crs, &mut rng);
 
@@ -502,16 +602,16 @@ mod tests {
             a_consts: vec![crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine()],
             b_consts: vec![Fr::rand(&mut rng), Fr::rand(&mut rng)],
             gamma: vec![vec![Fr::one()], vec![Fr::zero()]],
-            target: crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine()
+            target: crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine(),
         };
-        let proof: EquProof<F> = equ.prove(&xvars, &scalar_yvars, &xcoms, &scalar_ycoms, &crs, &mut rng);
+        let proof: EquProof<F> =
+            equ.prove(&xvars, &scalar_yvars, &xcoms, &scalar_ycoms, &crs, &mut rng);
 
         assert_eq!(proof.equ_type, EquType::MultiScalarG1);
     }
 
     #[test]
     fn test_MSMEG1_cproof_is_commit_and_prove() {
-
         std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
         let mut rng = test_rng();
         let mut rng2 = test_rng();
@@ -519,22 +619,21 @@ mod tests {
 
         let xvars: Vec<G1Affine> = vec![
             crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine(),
-            crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine()
+            crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine(),
         ];
-        let scalar_yvars: Vec<Fr> = vec![
-            Fr::rand(&mut rng)
-        ];
+        let scalar_yvars: Vec<Fr> = vec![Fr::rand(&mut rng)];
         let equ: MSMEG1<F> = MSMEG1::<F> {
             a_consts: vec![crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine()],
             b_consts: vec![Fr::rand(&mut rng), Fr::rand(&mut rng)],
             gamma: vec![vec![Fr::one()], vec![Fr::zero()]],
-            target: crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine()
+            target: crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine(),
         };
 
         // Individually commit then prove
         let xcoms: Commit1<F> = batch_commit_G1(&xvars, &crs, &mut rng);
         let scalar_ycoms: Commit2<F> = batch_commit_scalar_to_B2(&scalar_yvars, &crs, &mut rng);
-        let proof: EquProof<F> = equ.prove(&xvars, &scalar_yvars, &xcoms, &scalar_ycoms, &crs, &mut rng);
+        let proof: EquProof<F> =
+            equ.prove(&xvars, &scalar_yvars, &xcoms, &scalar_ycoms, &crs, &mut rng);
         let cproof = CProof::<F> {
             xcoms,
             ycoms: scalar_ycoms,
@@ -565,17 +664,11 @@ mod tests {
 
     #[test]
     fn test_MSMEG2_proof_type() {
-
         let mut rng = test_rng();
         let crs = CRS::<F>::generate_crs(&mut rng);
 
-        let scalar_xvars: Vec<Fr> = vec![
-            Fr::rand(&mut rng),
-            Fr::rand(&mut rng)
-        ];
-        let yvars: Vec<G2Affine> = vec![
-            crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine()
-        ];
+        let scalar_xvars: Vec<Fr> = vec![Fr::rand(&mut rng), Fr::rand(&mut rng)];
+        let yvars: Vec<G2Affine> = vec![crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine()];
         let scalar_xcoms: Commit1<F> = batch_commit_scalar_to_B1(&scalar_xvars, &crs, &mut rng);
         let ycoms: Commit2<F> = batch_commit_G2(&yvars, &crs, &mut rng);
 
@@ -583,45 +676,41 @@ mod tests {
             a_consts: vec![Fr::rand(&mut rng)],
             b_consts: vec![
                 crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine(),
-                crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine()
+                crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine(),
             ],
             gamma: vec![vec![Fr::one()], vec![Fr::zero()]],
-            target: crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine()
+            target: crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine(),
         };
-        let proof: EquProof<F> = equ.prove(&scalar_xvars, &yvars, &scalar_xcoms, &ycoms, &crs, &mut rng);
+        let proof: EquProof<F> =
+            equ.prove(&scalar_xvars, &yvars, &scalar_xcoms, &ycoms, &crs, &mut rng);
 
         assert_eq!(proof.equ_type, EquType::MultiScalarG2);
     }
 
     #[test]
     fn test_MSMEG2_cproof_is_commit_and_prove() {
-
         let mut rng = test_rng();
         let mut rng2 = test_rng();
         let crs = CRS::<F>::generate_crs(&mut rng);
 
-        let scalar_xvars: Vec<Fr> = vec![
-            Fr::rand(&mut rng),
-            Fr::rand(&mut rng)
-        ];
-        let yvars: Vec<G2Affine> = vec![
-            crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine()
-        ];
+        let scalar_xvars: Vec<Fr> = vec![Fr::rand(&mut rng), Fr::rand(&mut rng)];
+        let yvars: Vec<G2Affine> = vec![crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine()];
 
         let equ: MSMEG2<F> = MSMEG2::<F> {
             a_consts: vec![Fr::rand(&mut rng)],
             b_consts: vec![
                 crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine(),
-                crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine()
+                crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine(),
             ],
             gamma: vec![vec![Fr::one()], vec![Fr::zero()]],
-            target: crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine()
+            target: crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine(),
         };
 
         // Individually commit then prove
         let scalar_xcoms: Commit1<F> = batch_commit_scalar_to_B1(&scalar_xvars, &crs, &mut rng);
         let ycoms: Commit2<F> = batch_commit_G2(&yvars, &crs, &mut rng);
-        let proof: EquProof<F> = equ.prove(&scalar_xvars, &yvars, &scalar_xcoms, &ycoms, &crs, &mut rng);
+        let proof: EquProof<F> =
+            equ.prove(&scalar_xvars, &yvars, &scalar_xcoms, &ycoms, &crs, &mut rng);
         let cproof = CProof::<F> {
             xcoms: scalar_xcoms,
             ycoms,
@@ -650,68 +739,63 @@ mod tests {
         assert_eq!(cproof, cproof2);
     }
 
-
     #[test]
     fn test_quadratic_proof_type() {
-
         let mut rng = test_rng();
         let crs = CRS::<F>::generate_crs(&mut rng);
 
-        let scalar_xvars: Vec<Fr> = vec![
-            Fr::rand(&mut rng),
-            Fr::rand(&mut rng)
-        ];
-        let scalar_yvars: Vec<Fr> = vec![
-            Fr::rand(&mut rng)
-        ];
+        let scalar_xvars: Vec<Fr> = vec![Fr::rand(&mut rng), Fr::rand(&mut rng)];
+        let scalar_yvars: Vec<Fr> = vec![Fr::rand(&mut rng)];
 
         let equ: QuadEqu<F> = QuadEqu::<F> {
             a_consts: vec![Fr::rand(&mut rng)],
-            b_consts: vec![
-                Fr::rand(&mut rng),
-                Fr::rand(&mut rng)
-            ],
+            b_consts: vec![Fr::rand(&mut rng), Fr::rand(&mut rng)],
             gamma: vec![vec![Fr::one()], vec![Fr::zero()]],
-            target: Fr::rand(&mut rng)
+            target: Fr::rand(&mut rng),
         };
 
         // Individually commit then prove
         let scalar_xcoms: Commit1<F> = batch_commit_scalar_to_B1(&scalar_xvars, &crs, &mut rng);
         let scalar_ycoms: Commit2<F> = batch_commit_scalar_to_B2(&scalar_yvars, &crs, &mut rng);
-        let proof: EquProof<F> = equ.prove(&scalar_xvars, &scalar_yvars, &scalar_xcoms, &scalar_ycoms, &crs, &mut rng);
+        let proof: EquProof<F> = equ.prove(
+            &scalar_xvars,
+            &scalar_yvars,
+            &scalar_xcoms,
+            &scalar_ycoms,
+            &crs,
+            &mut rng,
+        );
 
         assert_eq!(proof.equ_type, EquType::Quadratic);
     }
 
     #[test]
     fn test_quadratic_cproof_is_commit_and_prove() {
-
         let mut rng = test_rng();
         let mut rng2 = test_rng();
         let crs = CRS::<F>::generate_crs(&mut rng);
 
-        let scalar_xvars: Vec<Fr> = vec![
-            Fr::rand(&mut rng),
-            Fr::rand(&mut rng)
-        ];
-        let scalar_yvars: Vec<Fr> = vec![
-            Fr::rand(&mut rng)
-        ];
+        let scalar_xvars: Vec<Fr> = vec![Fr::rand(&mut rng), Fr::rand(&mut rng)];
+        let scalar_yvars: Vec<Fr> = vec![Fr::rand(&mut rng)];
 
         let equ: QuadEqu<F> = QuadEqu::<F> {
             a_consts: vec![Fr::rand(&mut rng)],
-            b_consts: vec![
-                Fr::rand(&mut rng),
-                Fr::rand(&mut rng)
-            ],
+            b_consts: vec![Fr::rand(&mut rng), Fr::rand(&mut rng)],
             gamma: vec![vec![Fr::one()], vec![Fr::zero()]],
-            target: Fr::rand(&mut rng)
+            target: Fr::rand(&mut rng),
         };
 
         // Individually commit then prove
         let scalar_xcoms: Commit1<F> = batch_commit_scalar_to_B1(&scalar_xvars, &crs, &mut rng);
         let scalar_ycoms: Commit2<F> = batch_commit_scalar_to_B2(&scalar_yvars, &crs, &mut rng);
-        let proof: EquProof<F> = equ.prove(&scalar_xvars, &scalar_yvars, &scalar_xcoms, &scalar_ycoms, &crs, &mut rng);
+        let proof: EquProof<F> = equ.prove(
+            &scalar_xvars,
+            &scalar_yvars,
+            &scalar_xcoms,
+            &scalar_ycoms,
+            &crs,
+            &mut rng,
+        );
         let cproof = CProof::<F> {
             xcoms: scalar_xcoms,
             ycoms: scalar_ycoms,
@@ -733,7 +817,6 @@ mod tests {
             let _ = Fr::rand(&mut rng2);
         }
         let _ = Fr::rand(&mut rng2);
-
 
         // Use the helper function to commit-and-prove in one step
         let cproof2 = equ.commit_and_prove(&scalar_xvars, &scalar_yvars, &crs, &mut rng2);

--- a/src/prover/prove.rs
+++ b/src/prover/prove.rs
@@ -13,6 +13,7 @@
 //! See the [`statement`](crate::statement) module for more details about the structure of the equations being proven about.
 
 use ark_ec::pairing::Pairing;
+use ark_ec::pairing::PairingOutput;
 use ark_std::{rand::Rng, UniformRand};
 
 use super::commit::*;
@@ -63,7 +64,7 @@ pub struct CProof<E: Pairing> {
     pub equ_proofs: Vec<EquProof<E>>,
 }
 
-impl<E: Pairing> Provable<E, E::G1Affine, E::G2Affine, E::TargetField> for PPE<E> {
+impl<E: Pairing> Provable<E, E::G1Affine, E::G2Affine, PairingOutput<E>> for PPE<E> {
     fn commit_and_prove<CR>(
         &self,
         xvars: &[E::G1Affine],
@@ -498,7 +499,7 @@ mod tests {
     type G1Affine = <F as Pairing>::G1Affine;
     type G2Affine = <F as Pairing>::G2Affine;
     type Fr = <F as Pairing>::ScalarField;
-    type Fqk = <F as Pairing>::TargetField;
+    type GT = PairingOutput<F>;
 
     #[test]
     fn test_PPE_proof_type() {
@@ -520,7 +521,7 @@ mod tests {
                 crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine(),
             ],
             gamma: vec![vec![Fr::one()], vec![Fr::zero()]],
-            target: Fqk::rand(&mut rng),
+            target: GT::rand(&mut rng),
         };
         let proof: EquProof<F> = equ.prove(&xvars, &yvars, &xcoms, &ycoms, &crs, &mut rng);
 
@@ -546,7 +547,7 @@ mod tests {
                 crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine(),
             ],
             gamma: vec![vec![Fr::one()], vec![Fr::zero()]],
-            target: Fqk::rand(&mut rng),
+            target: GT::rand(&mut rng),
         };
 
         // Individually commit then prove
@@ -573,7 +574,7 @@ mod tests {
         for _ in 0..equ.b_consts.len() {
             let _ = Fr::rand(&mut rng2);
         }
-        let _ = Fqk::rand(&mut rng2);
+        let _ = GT::rand(&mut rng2);
 
         // Use the helper function to commit-and-prove in one step
         let cproof2 = equ.commit_and_prove(&xvars, &yvars, &crs, &mut rng2);

--- a/src/prover/prove.rs
+++ b/src/prover/prove.rs
@@ -16,10 +16,13 @@ use ark_ec::pairing::Pairing;
 use ark_ec::pairing::PairingOutput;
 use ark_std::{rand::Rng, UniformRand};
 
-use super::commit::*;
-use crate::data_structures::*;
-use crate::generator::*;
-use crate::statement::*;
+use super::commit::{
+    batch_commit_G1, batch_commit_G2, batch_commit_scalar_to_B1, batch_commit_scalar_to_B2,
+    Commit1, Commit2,
+};
+use crate::data_structures::{col_vec_to_vec, vec_to_col_vec, Com1, Com2, Mat, Matrix, B1, B2};
+use crate::generator::CRS;
+use crate::statement::{EquType, QuadEqu, MSMEG1, MSMEG2, PPE};
 
 /// A collection  of attributes containing prover functionality for an [`Equation`](crate::statement::Equation).
 pub trait Provable<E: Pairing, A1, A2, AT> {
@@ -493,6 +496,8 @@ mod tests {
     use ark_ff::{One, UniformRand, Zero};
     use ark_std::ops::Mul;
     use ark_std::test_rng;
+
+    use crate::AbstractCrs;
 
     use super::*;
 

--- a/src/prover/prove.rs
+++ b/src/prover/prove.rs
@@ -74,8 +74,8 @@ impl<E: Pairing> Provable<E, E::G1Affine, E::G2Affine, E::TargetField> for PPE<E
     where
         CR: Rng,
     {
-        let xcoms: Commit1<E> = batch_commit_G1(&xvars, crs, rng);
-        let ycoms: Commit2<E> = batch_commit_G2(&yvars, crs, rng);
+        let xcoms: Commit1<E> = batch_commit_G1(xvars, crs, rng);
+        let ycoms: Commit2<E> = batch_commit_G2(yvars, crs, rng);
 
         CProof::<E> {
             xcoms: xcoms.clone(),
@@ -127,8 +127,8 @@ impl<E: Pairing> Provable<E, E::G1Affine, E::G2Affine, E::TargetField> for PPE<E
         // (2 x n) field matrix
         let x_rand_stmt = x_rand_trans.right_mul(&self.gamma, is_parallel);
         // (2 x 1) Com2 matrix
-        let x_rand_stmt_lin_y = vec_to_col_vec(&Com2::<E>::batch_linear_map(&yvars))
-            .left_mul(&x_rand_stmt, is_parallel);
+        let x_rand_stmt_lin_y =
+            vec_to_col_vec(&Com2::<E>::batch_linear_map(yvars)).left_mul(&x_rand_stmt, is_parallel);
 
         // (2 x 2) field matrix
         let pf_rand_stmt = x_rand_trans
@@ -148,8 +148,8 @@ impl<E: Pairing> Provable<E, E::G1Affine, E::G2Affine, E::TargetField> for PPE<E
         // (2 x m) field matrix
         let y_rand_stmt = y_rand_trans.right_mul(&self.gamma.transpose(), is_parallel);
         // (2 x 1) Com1 matrix
-        let y_rand_stmt_lin_x = vec_to_col_vec(&Com1::<E>::batch_linear_map(&xvars))
-            .left_mul(&y_rand_stmt, is_parallel);
+        let y_rand_stmt_lin_x =
+            vec_to_col_vec(&Com1::<E>::batch_linear_map(xvars)).left_mul(&y_rand_stmt, is_parallel);
 
         // (2 x 1) Com1 matrix
         let pf_rand_com1 = vec_to_col_vec(&crs.u).left_mul(&pf_rand, is_parallel);
@@ -177,8 +177,8 @@ impl<E: Pairing> Provable<E, E::G1Affine, E::ScalarField, E::G1Affine> for MSMEG
     where
         CR: Rng,
     {
-        let xcoms: Commit1<E> = batch_commit_G1(&xvars, crs, rng);
-        let scalar_ycoms: Commit2<E> = batch_commit_scalar_to_B2(&scalar_yvars, crs, rng);
+        let xcoms: Commit1<E> = batch_commit_G1(xvars, crs, rng);
+        let scalar_ycoms: Commit2<E> = batch_commit_scalar_to_B2(scalar_yvars, crs, rng);
 
         CProof::<E> {
             xcoms: xcoms.clone(),
@@ -222,15 +222,14 @@ impl<E: Pairing> Provable<E, E::G1Affine, E::ScalarField, E::G1Affine> for MSMEG
             vec![vec![E::ScalarField::rand(rng), E::ScalarField::rand(rng)]];
 
         // (2 x 1) Com2 matrix
-        let x_rand_lin_b =
-            vec_to_col_vec(&Com2::<E>::batch_scalar_linear_map(&self.b_consts, &crs))
-                .left_mul(&x_rand_trans, is_parallel);
+        let x_rand_lin_b = vec_to_col_vec(&Com2::<E>::batch_scalar_linear_map(&self.b_consts, crs))
+            .left_mul(&x_rand_trans, is_parallel);
 
         // (2 x n) field matrix
         let x_rand_stmt = x_rand_trans.right_mul(&self.gamma, is_parallel);
         // (2 x 1) Com2 matrix
         let x_rand_stmt_lin_y =
-            vec_to_col_vec(&Com2::<E>::batch_scalar_linear_map(&scalar_yvars, &crs))
+            vec_to_col_vec(&Com2::<E>::batch_scalar_linear_map(scalar_yvars, crs))
                 .left_mul(&x_rand_stmt, is_parallel);
 
         // (2 x 1) field matrix
@@ -252,8 +251,8 @@ impl<E: Pairing> Provable<E, E::G1Affine, E::ScalarField, E::G1Affine> for MSMEG
         // (1 x m) field matrix
         let y_rand_stmt = y_rand_trans.right_mul(&self.gamma.transpose(), is_parallel);
         // (1 x 1) Com1 matrix
-        let y_rand_stmt_lin_x = vec_to_col_vec(&Com1::<E>::batch_linear_map(&xvars))
-            .left_mul(&y_rand_stmt, is_parallel);
+        let y_rand_stmt_lin_x =
+            vec_to_col_vec(&Com1::<E>::batch_linear_map(xvars)).left_mul(&y_rand_stmt, is_parallel);
 
         // (1 x 1) Com1 matrix
         let pf_rand_com1 = vec_to_col_vec(&crs.u).left_mul(&pf_rand, is_parallel);
@@ -281,8 +280,8 @@ impl<E: Pairing> Provable<E, E::ScalarField, E::G2Affine, E::G2Affine> for MSMEG
     where
         CR: Rng,
     {
-        let scalar_xcoms: Commit1<E> = batch_commit_scalar_to_B1(&scalar_xvars, crs, rng);
-        let ycoms: Commit2<E> = batch_commit_G2(&yvars, crs, rng);
+        let scalar_xcoms: Commit1<E> = batch_commit_scalar_to_B1(scalar_xvars, crs, rng);
+        let ycoms: Commit2<E> = batch_commit_G2(yvars, crs, rng);
 
         CProof::<E> {
             xcoms: scalar_xcoms.clone(),
@@ -334,8 +333,8 @@ impl<E: Pairing> Provable<E, E::ScalarField, E::G2Affine, E::G2Affine> for MSMEG
         // (1 x n) field matrix
         let x_rand_stmt = x_rand_trans.right_mul(&self.gamma, is_parallel);
         // (1 x 1) Com2 matrix
-        let x_rand_stmt_lin_y = vec_to_col_vec(&Com2::<E>::batch_linear_map(&yvars))
-            .left_mul(&x_rand_stmt, is_parallel);
+        let x_rand_stmt_lin_y =
+            vec_to_col_vec(&Com2::<E>::batch_linear_map(yvars)).left_mul(&x_rand_stmt, is_parallel);
 
         // (1 x 2) field matrix
         let pf_rand_stmt = x_rand_trans
@@ -349,15 +348,14 @@ impl<E: Pairing> Provable<E, E::ScalarField, E::G2Affine, E::G2Affine> for MSMEG
         assert_eq!(pi.len(), 1);
 
         // (2 x 1) Com1 matrix
-        let y_rand_lin_a =
-            vec_to_col_vec(&Com1::<E>::batch_scalar_linear_map(&self.a_consts, &crs))
-                .left_mul(&y_rand_trans, is_parallel);
+        let y_rand_lin_a = vec_to_col_vec(&Com1::<E>::batch_scalar_linear_map(&self.a_consts, crs))
+            .left_mul(&y_rand_trans, is_parallel);
 
         // (2 x m') field matrix
         let y_rand_stmt = y_rand_trans.right_mul(&self.gamma.transpose(), is_parallel);
         // (2 x 1) Com1 matrix
         let y_rand_stmt_lin_x =
-            vec_to_col_vec(&Com1::<E>::batch_scalar_linear_map(&scalar_xvars, &crs))
+            vec_to_col_vec(&Com1::<E>::batch_scalar_linear_map(scalar_xvars, crs))
                 .left_mul(&y_rand_stmt, is_parallel);
 
         // (2 x 1) Com1 matrix
@@ -387,8 +385,8 @@ impl<E: Pairing> Provable<E, E::ScalarField, E::ScalarField, E::ScalarField> for
     where
         CR: Rng,
     {
-        let scalar_xcoms: Commit1<E> = batch_commit_scalar_to_B1(&scalar_xvars, crs, rng);
-        let scalar_ycoms: Commit2<E> = batch_commit_scalar_to_B2(&scalar_yvars, crs, rng);
+        let scalar_xcoms: Commit1<E> = batch_commit_scalar_to_B1(scalar_xvars, crs, rng);
+        let scalar_ycoms: Commit2<E> = batch_commit_scalar_to_B2(scalar_yvars, crs, rng);
 
         CProof::<E> {
             xcoms: scalar_xcoms.clone(),
@@ -436,15 +434,14 @@ impl<E: Pairing> Provable<E, E::ScalarField, E::ScalarField, E::ScalarField> for
         // field element T, in GS parlance
         let pf_rand: Matrix<E::ScalarField> = vec![vec![E::ScalarField::rand(rng)]];
 
-        let x_rand_lin_b =
-            vec_to_col_vec(&Com2::<E>::batch_scalar_linear_map(&self.b_consts, &crs))
-                .left_mul(&x_rand_trans, is_parallel);
+        let x_rand_lin_b = vec_to_col_vec(&Com2::<E>::batch_scalar_linear_map(&self.b_consts, crs))
+            .left_mul(&x_rand_trans, is_parallel);
 
         // (1 x n') field matrix
         let x_rand_stmt = x_rand_trans.right_mul(&self.gamma, is_parallel);
         // (1 x 1) Com2 matrix
         let x_rand_stmt_lin_y =
-            vec_to_col_vec(&Com2::<E>::batch_scalar_linear_map(&scalar_yvars, &crs))
+            vec_to_col_vec(&Com2::<E>::batch_scalar_linear_map(scalar_yvars, crs))
                 .left_mul(&x_rand_stmt, is_parallel);
 
         // (1 x 2) field matrix
@@ -460,15 +457,14 @@ impl<E: Pairing> Provable<E, E::ScalarField, E::ScalarField, E::ScalarField> for
         assert_eq!(pi.len(), 1);
 
         // (1 x 1) Com1 matrix
-        let y_rand_lin_a =
-            vec_to_col_vec(&Com1::<E>::batch_scalar_linear_map(&self.a_consts, &crs))
-                .left_mul(&y_rand_trans, is_parallel);
+        let y_rand_lin_a = vec_to_col_vec(&Com1::<E>::batch_scalar_linear_map(&self.a_consts, crs))
+            .left_mul(&y_rand_trans, is_parallel);
 
         // (1 x m') field matrix
         let y_rand_stmt = y_rand_trans.right_mul(&self.gamma.transpose(), is_parallel);
         // (1 x 1) Com1 matrix
         let y_rand_stmt_lin_x =
-            vec_to_col_vec(&Com1::<E>::batch_scalar_linear_map(&scalar_xvars, &crs))
+            vec_to_col_vec(&Com1::<E>::batch_scalar_linear_map(scalar_xvars, crs))
                 .left_mul(&y_rand_stmt, is_parallel);
 
         // (1 x 1) Com1 matrix

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -4,7 +4,7 @@
 //!
 //! - `A` and `B` are vectors representing public constants in the equation,
 //! - `X` and `Y` are vectors representing private variables in the equation (introduced on prove),
-//! - `Γ` is a matrix of public [scalar](ark_ec::PairingEngine::Fr) constants defining how to scalar multiply
+//! - `Γ` is a matrix of public [scalar](ark_ec::Pairing::Fr) constants defining how to scalar multiply
 //!     the corresponding variables being paired together,
 //! - `t` is a public constant representing the RHS of the equation, and
 //! - `*` is the specified pairing, applied entry-wise to the corresponding elements in each vector.
@@ -13,13 +13,13 @@
 //! and must be one of the following four types, each defined over a bilinear group:
 //!
 //! 1) **Pairing-product equation** ([`PPE`](self::PPE)):&emsp;&emsp;&emsp;&emsp;&emsp;&emsp; `(G1, G2, GT)` with
-//!     [`e`](ark_ec::PairingEngine::pairing)` : G1 x G2 -> GT` as the equipped pairing.
+//!     [`e`](ark_ec::Pairing::pairing)` : G1 x G2 -> GT` as the equipped pairing.
 //! 2) **Multi-scalar mult. equation in G1** ([`MSMEG1`](self::MSMEG1)):&emsp;`(G1, Fr, G1)`
 //!     with [point-scalar multiplication](ark_ec::AffineCurve::mul) as the equipped pairing.
 //! 3) **Multi-scalar mult. equation in G2** ([`MSMEG2`](self::MSMEG2)):&emsp;`(Fr, G2, G2)`
 //!     with [point-scalar multiplication](ark_ec::AffineCurve::mul) as the equipped pairing.
 //! 4) **Quadratic equation** ([`QuadEqu`](self::QuadEqu)):&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&ensp;`(Fr, Fr, Fr)`
-//!     with [scalar](ark_ec::PairingEngine::Fr) multiplication as the equipped pairing.
+//!     with [scalar](ark_ec::Pairing::Fr) multiplication as the equipped pairing.
 //!
 //! The Groth-Sahai proof system expects that **each** equation is defined with respect to the list of variables
 //! that span across **ALL** equations being proven about. For example, if one wishes to prove
@@ -31,7 +31,7 @@
 //! of bilinear group arithmetic and pairings in order to form a valid Groth-Sahai statement.
 //! This API does not provide such functionality.
 
-use ark_ec::PairingEngine;
+use ark_ec::pairing::Pairing;
 
 use crate::data_structures::Matrix;
 use crate::prover::Provable;
@@ -43,7 +43,7 @@ pub enum EquType {
     PairingProduct,
     MultiScalarG1,
     MultiScalarG2,
-    Quadratic
+    Quadratic,
 }
 
 /// A marker trait for an arbitrary Groth-Sahai [`Equation`](self::Equation).
@@ -51,11 +51,7 @@ pub trait Equ {}
 
 /// A single equation, defined over an arbitrary bilinear group `(A1, A2, AT)`, that forms
 /// the atomic unit for a Groth-Sahai [`Statement`](self::Statement).
-pub trait Equation<E: PairingEngine, A1, A2, AT>:
-    Equ
-    + Provable<E, A1, A2, AT>
-    + Verifiable<E>
-{
+pub trait Equation<E: Pairing, A1, A2, AT>: Equ + Provable<E, A1, A2, AT> + Verifiable<E> {
     fn get_type(&self) -> EquType;
 }
 
@@ -63,83 +59,82 @@ pub trait Equation<E: PairingEngine, A1, A2, AT>:
 pub type Statement = Vec<dyn Equ>;
 
 /// A pairing-product equation, equipped with the bilinear group pairing
-/// [`e`](ark_ec::PairingEngine::pairing)` : G1 x G2 -> GT`.
+/// [`e`](ark_ec::Pairing::pairing)` : G1 x G2 -> GT`.
 ///
 /// For example, the equation `e(W, N) * e(U, V)^5 = t_T` can be expressed by the following
 /// (private) witness variables `X = [U, W]`, `Y = [V]`, (public) constants `A = [0]`, `B = [0, N]`,
 /// pairing exponent matrix `Γ = [[5], [0]]`, and `target = t_T` in `GT`.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct PPE<E: PairingEngine> {
+pub struct PPE<E: Pairing> {
     pub a_consts: Vec<E::G1Affine>,
     pub b_consts: Vec<E::G2Affine>,
-    pub gamma: Matrix<E::Fr>,
-    pub target: E::Fqk
+    pub gamma: Matrix<E::ScalarField>,
+    pub target: E::TargetField,
 }
 
-impl<E: PairingEngine> Equ for PPE<E> {}
-impl<E: PairingEngine> Equation<E, E::G1Affine, E::G2Affine, E::Fqk> for PPE<E> {
+impl<E: Pairing> Equ for PPE<E> {}
+impl<E: Pairing> Equation<E, E::G1Affine, E::G2Affine, E::TargetField> for PPE<E> {
     #[inline(always)]
     fn get_type(&self) -> EquType {
         EquType::PairingProduct
     }
 }
 
-/// A multi-scalar multiplication equation in [`G1`](ark_ec::PairingEngine::G1Affine), equipped with point-scalar multiplication as pairing.
+/// A multi-scalar multiplication equation in [`G1`](ark_ec::Pairing::G1Affine), equipped with point-scalar multiplication as pairing.
 ///
 /// For example, the equation `n * W + (v * U)^5 = t_1` can be expressed by the following
 /// (private) witness variables `X = [U, W]`, `Y = [v]`, (public) constants `A = [0]`, `B = [0, n]`,
 /// pairing exponent matrix `Γ = [[5], [0]]`, and `target = t_1` in `G1`.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct MSMEG1<E: PairingEngine> {
+pub struct MSMEG1<E: Pairing> {
     pub a_consts: Vec<E::G1Affine>,
-    pub b_consts: Vec<E::Fr>,
-    pub gamma: Matrix<E::Fr>,
-    pub target: E::G1Affine
+    pub b_consts: Vec<E::ScalarField>,
+    pub gamma: Matrix<E::ScalarField>,
+    pub target: E::G1Affine,
 }
 
-impl<E: PairingEngine> Equ for MSMEG1<E> {}
-impl<E: PairingEngine> Equation<E, E::G1Affine, E::Fr, E::G1Affine> for MSMEG1<E> {
+impl<E: Pairing> Equ for MSMEG1<E> {}
+impl<E: Pairing> Equation<E, E::G1Affine, E::ScalarField, E::G1Affine> for MSMEG1<E> {
     #[inline(always)]
     fn get_type(&self) -> EquType {
         EquType::MultiScalarG1
     }
 }
 
-/// A multi-scalar multiplication equation in [`G2`](ark_ec::PairingEngine::G2Affine), equipped with point-scalar multiplication as pairing.
+/// A multi-scalar multiplication equation in [`G2`](ark_ec::Pairing::G2Affine), equipped with point-scalar multiplication as pairing.
 ///
 /// For example, the equation `w * N + (u * V)^5 = t_2` can be expressed by the following
 /// (private) witness variables `X = [u, w]`, `Y = [V]`, (public) constants `A = [0]`, `B = [0, N]`,
 /// pairing exponent matrix `Γ = [[5], [0]]`, and `target = t_2` in `G2`.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct MSMEG2<E: PairingEngine> {
-    pub a_consts: Vec<E::Fr>,
+pub struct MSMEG2<E: Pairing> {
+    pub a_consts: Vec<E::ScalarField>,
     pub b_consts: Vec<E::G2Affine>,
-    pub gamma: Matrix<E::Fr>,
-    pub target: E::G2Affine
+    pub gamma: Matrix<E::ScalarField>,
+    pub target: E::G2Affine,
 }
-impl<E: PairingEngine> Equ for MSMEG2<E> {}
-impl<E: PairingEngine> Equation<E, E::Fr, E::G2Affine, E::G2Affine> for MSMEG2<E> {
+impl<E: Pairing> Equ for MSMEG2<E> {}
+impl<E: Pairing> Equation<E, E::ScalarField, E::G2Affine, E::G2Affine> for MSMEG2<E> {
     #[inline(always)]
     fn get_type(&self) -> EquType {
         EquType::MultiScalarG2
     }
 }
 
-
-/// A quadratic equation in the [scalar field](ark_ec::PairingEngine::Fr), equipped with field multiplication as pairing.
+/// A quadratic equation in the [scalar field](ark_ec::Pairing::Fr), equipped with field multiplication as pairing.
 ///
 /// For example, the equation `w * n + (u * v)^5 = t_p` can be expressed by the following
 /// (private) witness variables `X = [u, w]`, `Y = [v]`, (public) constants `A = [0]`, `B = [0, n]`,
 /// pairing exponent matrix `Γ = [[5], [0]]`, and `target = t_p` in `Fr`.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct QuadEqu<E: PairingEngine> {
-    pub a_consts: Vec<E::Fr>,
-    pub b_consts: Vec<E::Fr>,
-    pub gamma: Matrix<E::Fr>,
-    pub target: E::Fr
+pub struct QuadEqu<E: Pairing> {
+    pub a_consts: Vec<E::ScalarField>,
+    pub b_consts: Vec<E::ScalarField>,
+    pub gamma: Matrix<E::ScalarField>,
+    pub target: E::ScalarField,
 }
-impl<E: PairingEngine> Equ for QuadEqu<E> {}
-impl<E: PairingEngine> Equation<E, E::Fr, E::Fr, E::Fr> for QuadEqu<E> {
+impl<E: Pairing> Equ for QuadEqu<E> {}
+impl<E: Pairing> Equation<E, E::ScalarField, E::ScalarField, E::ScalarField> for QuadEqu<E> {
     #[inline(always)]
     fn get_type(&self) -> EquType {
         EquType::Quadratic
@@ -150,20 +145,20 @@ impl<E: PairingEngine> Equation<E, E::Fr, E::Fr, E::Fr> for QuadEqu<E> {
 mod tests {
     #![allow(non_snake_case)]
 
-    use ark_bls12_381::{Bls12_381 as F};
-    use ark_ec::{PairingEngine, AffineCurve, ProjectiveCurve};
+    use ark_bls12_381::Bls12_381 as F;
+    use ark_ec::CurveGroup;
     use ark_ff::UniformRand;
+    use ark_std::ops::Mul;
     use ark_std::test_rng;
 
     use super::*;
     use crate::generator::*;
 
-    type Fr = <F as PairingEngine>::Fr;
-    type Fqk = <F as PairingEngine>::Fqk;
+    type Fr = <F as Pairing>::ScalarField;
+    type Fqk = <F as Pairing>::TargetField;
 
     #[test]
     fn test_PPE_equation_type() {
-
         let mut rng = test_rng();
         let crs = CRS::<F>::generate_crs(&mut rng);
 
@@ -171,7 +166,7 @@ mod tests {
             a_consts: vec![crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine()],
             b_consts: vec![crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine()],
             gamma: vec![vec![Fr::rand(&mut rng)]],
-            target: Fqk::rand(&mut rng)
+            target: Fqk::rand(&mut rng),
         };
 
         assert_eq!(equ.get_type(), EquType::PairingProduct);
@@ -179,7 +174,6 @@ mod tests {
 
     #[test]
     fn test_MSMEG1_equation_type() {
-
         let mut rng = test_rng();
         let crs = CRS::<F>::generate_crs(&mut rng);
 
@@ -187,7 +181,7 @@ mod tests {
             a_consts: vec![crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine()],
             b_consts: vec![Fr::rand(&mut rng)],
             gamma: vec![vec![Fr::rand(&mut rng)]],
-            target: crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine()
+            target: crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine(),
         };
 
         assert_eq!(equ.get_type(), EquType::MultiScalarG1);
@@ -195,7 +189,6 @@ mod tests {
 
     #[test]
     fn test_MSMEG2_equation_type() {
-
         let mut rng = test_rng();
         let crs = CRS::<F>::generate_crs(&mut rng);
 
@@ -203,7 +196,7 @@ mod tests {
             a_consts: vec![Fr::rand(&mut rng)],
             b_consts: vec![crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine()],
             gamma: vec![vec![Fr::rand(&mut rng)]],
-            target: crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine()
+            target: crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine(),
         };
 
         assert_eq!(equ.get_type(), EquType::MultiScalarG2);
@@ -211,14 +204,13 @@ mod tests {
 
     #[test]
     fn test_quadratic_equation_type() {
-
         let mut rng = test_rng();
 
         let equ: QuadEqu<F> = QuadEqu::<F> {
             a_consts: vec![Fr::rand(&mut rng)],
             b_consts: vec![Fr::rand(&mut rng)],
             gamma: vec![vec![Fr::rand(&mut rng)]],
-            target: Fr::rand(&mut rng)
+            target: Fr::rand(&mut rng),
         };
 
         assert_eq!(equ.get_type(), EquType::Quadratic);

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -31,7 +31,7 @@
 //! of bilinear group arithmetic and pairings in order to form a valid Groth-Sahai statement.
 //! This API does not provide such functionality.
 
-use ark_ec::pairing::Pairing;
+use ark_ec::pairing::{Pairing, PairingOutput};
 
 use crate::data_structures::Matrix;
 use crate::prover::Provable;
@@ -69,11 +69,11 @@ pub struct PPE<E: Pairing> {
     pub a_consts: Vec<E::G1Affine>,
     pub b_consts: Vec<E::G2Affine>,
     pub gamma: Matrix<E::ScalarField>,
-    pub target: E::TargetField,
+    pub target: PairingOutput<E>,
 }
 
 impl<E: Pairing> Equ for PPE<E> {}
-impl<E: Pairing> Equation<E, E::G1Affine, E::G2Affine, E::TargetField> for PPE<E> {
+impl<E: Pairing> Equation<E, E::G1Affine, E::G2Affine, PairingOutput<E>> for PPE<E> {
     #[inline(always)]
     fn get_type(&self) -> EquType {
         EquType::PairingProduct
@@ -155,7 +155,7 @@ mod tests {
     use crate::generator::*;
 
     type Fr = <F as Pairing>::ScalarField;
-    type Fqk = <F as Pairing>::TargetField;
+    type GT = PairingOutput<F>;
 
     #[test]
     fn test_PPE_equation_type() {
@@ -166,7 +166,7 @@ mod tests {
             a_consts: vec![crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine()],
             b_consts: vec![crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine()],
             gamma: vec![vec![Fr::rand(&mut rng)]],
-            target: Fqk::rand(&mut rng),
+            target: GT::rand(&mut rng),
         };
 
         assert_eq!(equ.get_type(), EquType::PairingProduct);

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -1,6 +1,6 @@
 //! Contains the functionality for verifying the satisfiability of Groth-Sahai equations over bilinear groups.
 //!
-//! Verifying an equation's proof primarily involves addition in [`BT`](crate::data_structures::ComT) (equiv. multiplication in 4 [`GT`](ark_ec::Pairing::Fqk))
+//! Verifying an equation's proof primarily involves addition in [`BT`](crate::data_structures::ComT) (equiv. additions in 4 [`GT`](ark_ec::Pairing::GT))
 //! and pairings over elements in [`B1`](crate::data_structures::Com1) and [`B2`](crate::data_structures::Com2).
 //!
 //! See the [`prover`](crate::prover) and [`statement`](crate::statement) modules for more details about the structure of the equations and their proofs.

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -65,7 +65,7 @@ impl<E: Pairing> Verifiable<E> for MSMEG1<E> {
 
         let com_x_lin_b = ComT::<E>::pairing_sum(
             &com_proof.xcoms.coms,
-            &Com2::<E>::batch_scalar_linear_map(&self.b_consts, &crs),
+            &Com2::<E>::batch_scalar_linear_map(&self.b_consts, crs),
         );
 
         let stmt_com_y: Matrix<Com2<E>> =
@@ -73,7 +73,7 @@ impl<E: Pairing> Verifiable<E> for MSMEG1<E> {
         let com_x_stmt_com_y =
             ComT::<E>::pairing_sum(&com_proof.xcoms.coms, &col_vec_to_vec(&stmt_com_y));
 
-        let lin_t = ComT::<E>::linear_map_MSMEG1(&self.target, &crs);
+        let lin_t = ComT::<E>::linear_map_MSMEG1(&self.target, crs);
 
         let com1_pf2 = ComT::<E>::pairing_sum(&crs.u, &com_proof.equ_proofs[0].pi);
 
@@ -93,7 +93,7 @@ impl<E: Pairing> Verifiable<E> for MSMEG2<E> {
         let is_parallel = true;
 
         let lin_a_com_y = ComT::<E>::pairing_sum(
-            &Com1::<E>::batch_scalar_linear_map(&self.a_consts, &crs),
+            &Com1::<E>::batch_scalar_linear_map(&self.a_consts, crs),
             &com_proof.ycoms.coms,
         );
 
@@ -107,7 +107,7 @@ impl<E: Pairing> Verifiable<E> for MSMEG2<E> {
         let com_x_stmt_com_y =
             ComT::<E>::pairing_sum(&com_proof.xcoms.coms, &col_vec_to_vec(&stmt_com_y));
 
-        let lin_t = ComT::<E>::linear_map_MSMEG2(&self.target, &crs);
+        let lin_t = ComT::<E>::linear_map_MSMEG2(&self.target, crs);
 
         let com1_pf2 = ComT::<E>::pairing(crs.u[0], com_proof.equ_proofs[0].pi[0]);
 
@@ -127,13 +127,13 @@ impl<E: Pairing> Verifiable<E> for QuadEqu<E> {
         let is_parallel = true;
 
         let lin_a_com_y = ComT::<E>::pairing_sum(
-            &Com1::<E>::batch_scalar_linear_map(&self.a_consts, &crs),
+            &Com1::<E>::batch_scalar_linear_map(&self.a_consts, crs),
             &com_proof.ycoms.coms,
         );
 
         let com_x_lin_b = ComT::<E>::pairing_sum(
             &com_proof.xcoms.coms,
-            &Com2::<E>::batch_scalar_linear_map(&self.b_consts, &crs),
+            &Com2::<E>::batch_scalar_linear_map(&self.b_consts, crs),
         );
 
         let stmt_com_y: Matrix<Com2<E>> =
@@ -141,7 +141,7 @@ impl<E: Pairing> Verifiable<E> for QuadEqu<E> {
         let com_x_stmt_com_y =
             ComT::<E>::pairing_sum(&com_proof.xcoms.coms, &col_vec_to_vec(&stmt_com_y));
 
-        let lin_t = ComT::<E>::linear_map_quad(&self.target, &crs);
+        let lin_t = ComT::<E>::linear_map_quad(&self.target, crs);
 
         let com1_pf2 = ComT::<E>::pairing(crs.u[0], com_proof.equ_proofs[0].pi[0]);
 

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -77,8 +77,7 @@ impl<E: Pairing> Verifiable<E> for MSMEG1<E> {
 
         let com1_pf2 = ComT::<E>::pairing_sum(&crs.u, &com_proof.equ_proofs[0].pi);
 
-        let pf1_com2 =
-            ComT::<E>::pairing(com_proof.equ_proofs[0].theta[0].clone(), crs.v[0].clone());
+        let pf1_com2 = ComT::<E>::pairing(com_proof.equ_proofs[0].theta[0], crs.v[0]);
 
         let lhs: ComT<E> = lin_a_com_y + com_x_lin_b + com_x_stmt_com_y;
         let rhs: ComT<E> = lin_t + com1_pf2 + pf1_com2;
@@ -110,7 +109,7 @@ impl<E: Pairing> Verifiable<E> for MSMEG2<E> {
 
         let lin_t = ComT::<E>::linear_map_MSMEG2(&self.target, &crs);
 
-        let com1_pf2 = ComT::<E>::pairing(crs.u[0].clone(), com_proof.equ_proofs[0].pi[0].clone());
+        let com1_pf2 = ComT::<E>::pairing(crs.u[0], com_proof.equ_proofs[0].pi[0]);
 
         let pf1_com2 = ComT::<E>::pairing_sum(&com_proof.equ_proofs[0].theta, &crs.v);
 
@@ -144,10 +143,9 @@ impl<E: Pairing> Verifiable<E> for QuadEqu<E> {
 
         let lin_t = ComT::<E>::linear_map_quad(&self.target, &crs);
 
-        let com1_pf2 = ComT::<E>::pairing(crs.u[0].clone(), com_proof.equ_proofs[0].pi[0].clone());
+        let com1_pf2 = ComT::<E>::pairing(crs.u[0], com_proof.equ_proofs[0].pi[0]);
 
-        let pf1_com2 =
-            ComT::<E>::pairing(com_proof.equ_proofs[0].theta[0].clone(), crs.v[0].clone());
+        let pf1_com2 = ComT::<E>::pairing(com_proof.equ_proofs[0].theta[0], crs.v[0]);
 
         let lhs: ComT<E> = lin_a_com_y + com_x_lin_b + com_x_stmt_com_y;
         let rhs: ComT<E> = lin_t + com1_pf2 + pf1_com2;

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -7,10 +7,12 @@
 
 use ark_ec::pairing::Pairing;
 
-use crate::data_structures::*;
-use crate::generator::*;
+use crate::data_structures::{
+    col_vec_to_vec, vec_to_col_vec, Com1, Com2, ComT, Mat, Matrix, B1, B2, BT,
+};
+use crate::generator::CRS;
 use crate::prover::CProof;
-use crate::statement::*;
+use crate::statement::{Equation, QuadEqu, MSMEG1, MSMEG2, PPE};
 
 /// A collection of attributes containing verifier functionality for an [`Equation`](crate::statement::Equation).
 pub trait Verifiable<E: Pairing> {

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -1,11 +1,11 @@
 //! Contains the functionality for verifying the satisfiability of Groth-Sahai equations over bilinear groups.
 //!
-//! Verifying an equation's proof primarily involves addition in [`BT`](crate::data_structures::ComT) (equiv. multiplication in 4 [`GT`](ark_ec::PairingEngine::Fqk))
+//! Verifying an equation's proof primarily involves addition in [`BT`](crate::data_structures::ComT) (equiv. multiplication in 4 [`GT`](ark_ec::Pairing::Fqk))
 //! and pairings over elements in [`B1`](crate::data_structures::Com1) and [`B2`](crate::data_structures::Com2).
 //!
 //! See the [`prover`](crate::prover) and [`statement`](crate::statement) modules for more details about the structure of the equations and their proofs.
 
-use ark_ec::PairingEngine;
+use ark_ec::pairing::Pairing;
 
 use crate::data_structures::*;
 use crate::generator::*;
@@ -13,26 +13,31 @@ use crate::prover::CProof;
 use crate::statement::*;
 
 /// A collection of attributes containing verifier functionality for an [`Equation`](crate::statement::Equation).
-pub trait Verifiable<E: PairingEngine> {
-
+pub trait Verifiable<E: Pairing> {
     /// Verifies that a single Groth-Sahai equation is satisfied using the prover's committed `x` and `y` variables.
     fn verify(&self, com_proof: &CProof<E>, crs: &CRS<E>) -> bool;
 }
 
-impl<E: PairingEngine> Verifiable<E> for PPE<E> {
-
+impl<E: Pairing> Verifiable<E> for PPE<E> {
     fn verify(&self, com_proof: &CProof<E>, crs: &CRS<E>) -> bool {
-
         assert_eq!(com_proof.equ_proofs.len(), 1);
         assert_eq!(self.get_type(), com_proof.equ_proofs[0].equ_type);
         let is_parallel = true;
 
-        let lin_a_com_y = ComT::<E>::pairing_sum(&Com1::<E>::batch_linear_map(&self.a_consts), &com_proof.ycoms.coms);
+        let lin_a_com_y = ComT::<E>::pairing_sum(
+            &Com1::<E>::batch_linear_map(&self.a_consts),
+            &com_proof.ycoms.coms,
+        );
 
-        let com_x_lin_b = ComT::<E>::pairing_sum(&com_proof.xcoms.coms, &Com2::<E>::batch_linear_map(&self.b_consts));
+        let com_x_lin_b = ComT::<E>::pairing_sum(
+            &com_proof.xcoms.coms,
+            &Com2::<E>::batch_linear_map(&self.b_consts),
+        );
 
-        let stmt_com_y: Matrix<Com2<E>> = vec_to_col_vec(&com_proof.ycoms.coms).left_mul(&self.gamma, is_parallel);
-        let com_x_stmt_com_y = ComT::<E>::pairing_sum(&com_proof.xcoms.coms, &col_vec_to_vec(&stmt_com_y));
+        let stmt_com_y: Matrix<Com2<E>> =
+            vec_to_col_vec(&com_proof.ycoms.coms).left_mul(&self.gamma, is_parallel);
+        let com_x_stmt_com_y =
+            ComT::<E>::pairing_sum(&com_proof.xcoms.coms, &col_vec_to_vec(&stmt_com_y));
 
         let lin_t = ComT::<E>::linear_map_PPE(&self.target);
 
@@ -47,26 +52,33 @@ impl<E: PairingEngine> Verifiable<E> for PPE<E> {
     }
 }
 
-impl<E: PairingEngine> Verifiable<E> for MSMEG1<E> {
-
+impl<E: Pairing> Verifiable<E> for MSMEG1<E> {
     fn verify(&self, com_proof: &CProof<E>, crs: &CRS<E>) -> bool {
-
         assert_eq!(com_proof.equ_proofs.len(), 1);
         assert_eq!(self.get_type(), com_proof.equ_proofs[0].equ_type);
         let is_parallel = true;
 
-        let lin_a_com_y = ComT::<E>::pairing_sum(&Com1::<E>::batch_linear_map(&self.a_consts), &com_proof.ycoms.coms);
+        let lin_a_com_y = ComT::<E>::pairing_sum(
+            &Com1::<E>::batch_linear_map(&self.a_consts),
+            &com_proof.ycoms.coms,
+        );
 
-        let com_x_lin_b = ComT::<E>::pairing_sum(&com_proof.xcoms.coms, &Com2::<E>::batch_scalar_linear_map(&self.b_consts, &crs));
+        let com_x_lin_b = ComT::<E>::pairing_sum(
+            &com_proof.xcoms.coms,
+            &Com2::<E>::batch_scalar_linear_map(&self.b_consts, &crs),
+        );
 
-        let stmt_com_y: Matrix<Com2<E>> = vec_to_col_vec(&com_proof.ycoms.coms).left_mul(&self.gamma, is_parallel);
-        let com_x_stmt_com_y = ComT::<E>::pairing_sum(&com_proof.xcoms.coms, &col_vec_to_vec(&stmt_com_y));
+        let stmt_com_y: Matrix<Com2<E>> =
+            vec_to_col_vec(&com_proof.ycoms.coms).left_mul(&self.gamma, is_parallel);
+        let com_x_stmt_com_y =
+            ComT::<E>::pairing_sum(&com_proof.xcoms.coms, &col_vec_to_vec(&stmt_com_y));
 
         let lin_t = ComT::<E>::linear_map_MSMEG1(&self.target, &crs);
 
         let com1_pf2 = ComT::<E>::pairing_sum(&crs.u, &com_proof.equ_proofs[0].pi);
 
-        let pf1_com2 = ComT::<E>::pairing(com_proof.equ_proofs[0].theta[0].clone(), crs.v[0].clone());
+        let pf1_com2 =
+            ComT::<E>::pairing(com_proof.equ_proofs[0].theta[0].clone(), crs.v[0].clone());
 
         let lhs: ComT<E> = lin_a_com_y + com_x_lin_b + com_x_stmt_com_y;
         let rhs: ComT<E> = lin_t + com1_pf2 + pf1_com2;
@@ -75,20 +87,26 @@ impl<E: PairingEngine> Verifiable<E> for MSMEG1<E> {
     }
 }
 
-impl<E: PairingEngine> Verifiable<E> for MSMEG2<E> {
-
+impl<E: Pairing> Verifiable<E> for MSMEG2<E> {
     fn verify(&self, com_proof: &CProof<E>, crs: &CRS<E>) -> bool {
-
         assert_eq!(com_proof.equ_proofs.len(), 1);
         assert_eq!(self.get_type(), com_proof.equ_proofs[0].equ_type);
         let is_parallel = true;
 
-        let lin_a_com_y = ComT::<E>::pairing_sum(&Com1::<E>::batch_scalar_linear_map(&self.a_consts, &crs), &com_proof.ycoms.coms);
+        let lin_a_com_y = ComT::<E>::pairing_sum(
+            &Com1::<E>::batch_scalar_linear_map(&self.a_consts, &crs),
+            &com_proof.ycoms.coms,
+        );
 
-        let com_x_lin_b = ComT::<E>::pairing_sum(&com_proof.xcoms.coms, &Com2::<E>::batch_linear_map(&self.b_consts));
+        let com_x_lin_b = ComT::<E>::pairing_sum(
+            &com_proof.xcoms.coms,
+            &Com2::<E>::batch_linear_map(&self.b_consts),
+        );
 
-        let stmt_com_y: Matrix<Com2<E>> = vec_to_col_vec(&com_proof.ycoms.coms).left_mul(&self.gamma, is_parallel);
-        let com_x_stmt_com_y = ComT::<E>::pairing_sum(&com_proof.xcoms.coms, &col_vec_to_vec(&stmt_com_y));
+        let stmt_com_y: Matrix<Com2<E>> =
+            vec_to_col_vec(&com_proof.ycoms.coms).left_mul(&self.gamma, is_parallel);
+        let com_x_stmt_com_y =
+            ComT::<E>::pairing_sum(&com_proof.xcoms.coms, &col_vec_to_vec(&stmt_com_y));
 
         let lin_t = ComT::<E>::linear_map_MSMEG2(&self.target, &crs);
 
@@ -103,26 +121,33 @@ impl<E: PairingEngine> Verifiable<E> for MSMEG2<E> {
     }
 }
 
-impl<E: PairingEngine> Verifiable<E> for QuadEqu<E> {
-
+impl<E: Pairing> Verifiable<E> for QuadEqu<E> {
     fn verify(&self, com_proof: &CProof<E>, crs: &CRS<E>) -> bool {
-
         assert_eq!(com_proof.equ_proofs.len(), 1);
         assert_eq!(self.get_type(), com_proof.equ_proofs[0].equ_type);
         let is_parallel = true;
 
-        let lin_a_com_y = ComT::<E>::pairing_sum(&Com1::<E>::batch_scalar_linear_map(&self.a_consts, &crs), &com_proof.ycoms.coms);
+        let lin_a_com_y = ComT::<E>::pairing_sum(
+            &Com1::<E>::batch_scalar_linear_map(&self.a_consts, &crs),
+            &com_proof.ycoms.coms,
+        );
 
-        let com_x_lin_b = ComT::<E>::pairing_sum(&com_proof.xcoms.coms, &Com2::<E>::batch_scalar_linear_map(&self.b_consts, &crs));
+        let com_x_lin_b = ComT::<E>::pairing_sum(
+            &com_proof.xcoms.coms,
+            &Com2::<E>::batch_scalar_linear_map(&self.b_consts, &crs),
+        );
 
-        let stmt_com_y: Matrix<Com2<E>> = vec_to_col_vec(&com_proof.ycoms.coms).left_mul(&self.gamma, is_parallel);
-        let com_x_stmt_com_y = ComT::<E>::pairing_sum(&com_proof.xcoms.coms, &col_vec_to_vec(&stmt_com_y));
+        let stmt_com_y: Matrix<Com2<E>> =
+            vec_to_col_vec(&com_proof.ycoms.coms).left_mul(&self.gamma, is_parallel);
+        let com_x_stmt_com_y =
+            ComT::<E>::pairing_sum(&com_proof.xcoms.coms, &col_vec_to_vec(&stmt_com_y));
 
         let lin_t = ComT::<E>::linear_map_quad(&self.target, &crs);
 
         let com1_pf2 = ComT::<E>::pairing(crs.u[0].clone(), com_proof.equ_proofs[0].pi[0].clone());
 
-        let pf1_com2 = ComT::<E>::pairing(com_proof.equ_proofs[0].theta[0].clone(), crs.v[0].clone());
+        let pf1_com2 =
+            ComT::<E>::pairing(com_proof.equ_proofs[0].theta[0].clone(), crs.v[0].clone());
 
         let lhs: ComT<E> = lin_a_com_y + com_x_lin_b + com_x_stmt_com_y;
         let rhs: ComT<E> = lin_t + com1_pf2 + pf1_com2;

--- a/tests/commit.rs
+++ b/tests/commit.rs
@@ -1,5 +1,4 @@
 #![allow(non_snake_case)]
-extern crate groth_sahai;
 
 #[cfg(test)]
 mod SXDH_commit_tests {

--- a/tests/commit.rs
+++ b/tests/commit.rs
@@ -4,26 +4,27 @@ extern crate groth_sahai;
 #[cfg(test)]
 mod SXDH_commit_tests {
 
-    use ark_bls12_381::{Bls12_381 as F};
-    use ark_ec::{PairingEngine, ProjectiveCurve, AffineCurve};
+    use ark_bls12_381::Bls12_381 as F;
+    use ark_ec::pairing::Pairing;
+    use ark_ec::CurveGroup;
     use ark_ff::UniformRand;
+    use ark_std::ops::Mul;
     use ark_std::test_rng;
 
-    use groth_sahai::{CRS, AbstractCrs};
     use groth_sahai::data_structures::*;
-//    use groth_sahai::commit::*;
+    use groth_sahai::{AbstractCrs, CRS};
+    //    use groth_sahai::commit::*;
 
-    type G1Projective = <F as PairingEngine>::G1Projective;
-    type G2Projective = <F as PairingEngine>::G2Projective;
-    type Fr = <F as PairingEngine>::Fr;
+    type G1Projective = <F as Pairing>::G1;
+    type G2Projective = <F as Pairing>::G2;
+    type Fr = <F as Pairing>::ScalarField;
 
     #[test]
     fn PPE_linear_bilinear_map_commutativity() {
-
         let mut rng = test_rng();
         let a1 = G1Projective::rand(&mut rng).into_affine();
         let a2 = G2Projective::rand(&mut rng).into_affine();
-        let at = F::pairing(a1.clone(), a2.clone());
+        let at = F::pairing(a1.clone(), a2.clone()).0;
         let b1 = Com1::<F>::linear_map(&a1);
         let b2 = Com2::<F>::linear_map(&a2);
 
@@ -35,7 +36,6 @@ mod SXDH_commit_tests {
 
     #[test]
     fn MSMEG1_linear_bilinear_map_commutativity() {
-
         let mut rng = test_rng();
         let key = CRS::<F>::generate_crs(&mut rng);
 
@@ -53,7 +53,6 @@ mod SXDH_commit_tests {
 
     #[test]
     fn MSMEG2_linear_bilinear_map_commutativity() {
-
         let mut rng = test_rng();
         let key = CRS::<F>::generate_crs(&mut rng);
 
@@ -71,7 +70,6 @@ mod SXDH_commit_tests {
 
     #[test]
     fn QuadEqu_linear_bilinear_map_commutativity() {
-
         let mut rng = test_rng();
         let key = CRS::<F>::generate_crs(&mut rng);
 

--- a/tests/commit.rs
+++ b/tests/commit.rs
@@ -23,7 +23,7 @@ mod SXDH_commit_tests {
         let mut rng = test_rng();
         let a1 = G1Projective::rand(&mut rng).into_affine();
         let a2 = G2Projective::rand(&mut rng).into_affine();
-        let at = F::pairing(a1, a2).0;
+        let at = F::pairing(a1, a2);
         let b1 = Com1::<F>::linear_map(&a1);
         let b2 = Com2::<F>::linear_map(&a2);
 

--- a/tests/commit.rs
+++ b/tests/commit.rs
@@ -24,11 +24,11 @@ mod SXDH_commit_tests {
         let mut rng = test_rng();
         let a1 = G1Projective::rand(&mut rng).into_affine();
         let a2 = G2Projective::rand(&mut rng).into_affine();
-        let at = F::pairing(a1.clone(), a2.clone()).0;
+        let at = F::pairing(a1, a2).0;
         let b1 = Com1::<F>::linear_map(&a1);
         let b2 = Com2::<F>::linear_map(&a2);
 
-        let bt_lin_bilin = ComT::<F>::pairing(b1.clone(), b2.clone());
+        let bt_lin_bilin = ComT::<F>::pairing(b1, b2);
         let bt_bilin_lin = ComT::<F>::linear_map_PPE(&at);
 
         assert_eq!(bt_lin_bilin, bt_bilin_lin);
@@ -45,7 +45,7 @@ mod SXDH_commit_tests {
         let b1 = Com1::<F>::linear_map(&a1);
         let b2 = Com2::<F>::scalar_linear_map(&a2, &key);
 
-        let bt_lin_bilin = ComT::<F>::pairing(b1.clone(), b2.clone());
+        let bt_lin_bilin = ComT::<F>::pairing(b1, b2);
         let bt_bilin_lin = ComT::<F>::linear_map_MSMEG1(&at, &key);
 
         assert_eq!(bt_lin_bilin, bt_bilin_lin);
@@ -62,7 +62,7 @@ mod SXDH_commit_tests {
         let b1 = Com1::<F>::scalar_linear_map(&a1, &key);
         let b2 = Com2::<F>::linear_map(&a2);
 
-        let bt_lin_bilin = ComT::<F>::pairing(b1.clone(), b2.clone());
+        let bt_lin_bilin = ComT::<F>::pairing(b1, b2);
         let bt_bilin_lin = ComT::<F>::linear_map_MSMEG2(&at, &key);
 
         assert_eq!(bt_lin_bilin, bt_bilin_lin);
@@ -79,7 +79,7 @@ mod SXDH_commit_tests {
         let b1 = Com1::<F>::scalar_linear_map(&a1, &key);
         let b2 = Com2::<F>::scalar_linear_map(&a2, &key);
 
-        let bt_lin_bilin = ComT::<F>::pairing(b1.clone(), b2.clone());
+        let bt_lin_bilin = ComT::<F>::pairing(b1, b2);
         let bt_bilin_lin = ComT::<F>::linear_map_quad(&at, &key);
 
         assert_eq!(bt_lin_bilin, bt_bilin_lin);

--- a/tests/prover.rs
+++ b/tests/prover.rs
@@ -48,13 +48,9 @@ mod SXDH_prover_tests {
         // Gamma = [ 5, 0 ] (i.e. only e(X_1, Y_1)^5 term)
         let gamma: Matrix<Fr> = vec![vec![Fr::from_str("5").unwrap()], vec![Fr::zero()]];
         // Target -> all together (n.b. e(X_1, Y_1)^5 = e(X_1, 5 Y_1) = e(5 X_1, Y_1) by the properties of non-degenerate bilinear maps)
-        let target: Fqk = F::pairing(xvars[1].clone(), b_consts[1].clone()).0
-            * F::pairing(a_consts[0].clone(), yvars[0].clone()).0
-            * F::pairing(
-                xvars[0].clone(),
-                yvars[0].mul(gamma[0][0].clone()).into_affine(),
-            )
-            .0;
+        let target: Fqk = F::pairing(xvars[1], b_consts[1]).0
+            * F::pairing(a_consts[0], yvars[0]).0
+            * F::pairing(xvars[0], yvars[0].mul(gamma[0][0]).into_affine()).0;
         let equ: PPE<F> = PPE::<F> {
             a_consts,
             b_consts,

--- a/tests/prover.rs
+++ b/tests/prover.rs
@@ -4,7 +4,7 @@
 mod SXDH_prover_tests {
 
     use ark_bls12_381::Bls12_381 as F;
-    use ark_ec::pairing::Pairing;
+    use ark_ec::pairing::{Pairing, PairingOutput};
     use ark_ec::{AffineRepr, CurveGroup};
     use ark_std::ops::Mul;
     use ark_std::str::FromStr;
@@ -19,7 +19,7 @@ mod SXDH_prover_tests {
     type G1Affine = <F as Pairing>::G1Affine;
     type G2Affine = <F as Pairing>::G2Affine;
     type Fr = <F as Pairing>::ScalarField;
-    type Fqk = <F as Pairing>::TargetField;
+    type GT = PairingOutput<F>;
 
     #[test]
     fn pairing_product_equation_verifies() {
@@ -47,9 +47,9 @@ mod SXDH_prover_tests {
         // Gamma = [ 5, 0 ] (i.e. only e(X_1, Y_1)^5 term)
         let gamma: Matrix<Fr> = vec![vec![Fr::from_str("5").unwrap()], vec![Fr::zero()]];
         // Target -> all together (n.b. e(X_1, Y_1)^5 = e(X_1, 5 Y_1) = e(5 X_1, Y_1) by the properties of non-degenerate bilinear maps)
-        let target: Fqk = F::pairing(xvars[1], b_consts[1]).0
-            * F::pairing(a_consts[0], yvars[0]).0
-            * F::pairing(xvars[0], yvars[0].mul(gamma[0][0]).into_affine()).0;
+        let target: GT = F::pairing(xvars[1], b_consts[1])
+            + F::pairing(a_consts[0], yvars[0])
+            + F::pairing(xvars[0], yvars[0].mul(gamma[0][0]).into_affine());
         let equ: PPE<F> = PPE::<F> {
             a_consts,
             b_consts,

--- a/tests/prover.rs
+++ b/tests/prover.rs
@@ -3,27 +3,27 @@ extern crate groth_sahai;
 
 #[cfg(test)]
 mod SXDH_prover_tests {
-    
-    use ark_bls12_381::{Bls12_381 as F};
-    use ark_ec::{PairingEngine, ProjectiveCurve, AffineCurve};
-    use ark_ff::{UniformRand, Zero, field_new};
-    use ark_std::test_rng;
 
-    use groth_sahai::{CRS, AbstractCrs};
+    use ark_bls12_381::Bls12_381 as F;
+    use ark_ec::pairing::Pairing;
+    use ark_ec::{AffineRepr, CurveGroup};
+    use ark_std::ops::Mul;
+    use ark_std::str::FromStr;
+    use ark_std::{test_rng, UniformRand, Zero};
+
     use groth_sahai::data_structures::*;
     use groth_sahai::prover::*;
     use groth_sahai::statement::*;
     use groth_sahai::verifier::Verifiable;
+    use groth_sahai::{AbstractCrs, CRS};
 
-    
-    type G1Affine = <F as PairingEngine>::G1Affine;
-    type G2Affine = <F as PairingEngine>::G2Affine;
-    type Fr = <F as PairingEngine>::Fr;
-    type Fqk = <F as PairingEngine>::Fqk;
+    type G1Affine = <F as Pairing>::G1Affine;
+    type G2Affine = <F as Pairing>::G2Affine;
+    type Fr = <F as Pairing>::ScalarField;
+    type Fqk = <F as Pairing>::TargetField;
 
     #[test]
     fn pairing_product_equation_verifies() {
-
         let mut rng = test_rng();
         let crs = CRS::<F>::generate_crs(&mut rng);
 
@@ -32,24 +32,34 @@ mod SXDH_prover_tests {
 
         // X = [ X_1, X_2 ] = [2 g1, 3 g1]
         let xvars: Vec<G1Affine> = vec![
-            crs.g1_gen.mul(field_new!(Fr, "2")).into_affine(),
-            crs.g1_gen.mul(field_new!(Fr, "3")).into_affine()
+            crs.g1_gen.mul(Fr::from_str("2").unwrap()).into_affine(),
+            crs.g1_gen.mul(Fr::from_str("3").unwrap()).into_affine(),
         ];
         // Y = [ Y_1 ] = [4 g2]
-        let yvars: Vec<G2Affine> = vec![
-            crs.g2_gen.mul(field_new!(Fr, "4")).into_affine()
-        ];
+        let yvars: Vec<G2Affine> = vec![crs.g2_gen.mul(Fr::from_str("4").unwrap()).into_affine()];
 
         // A = [ c_1 ] (i.e. e(c_1, Y_1) term in equation)
-        let a_consts: Vec<G1Affine> = vec![ crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine() ];
+        let a_consts: Vec<G1Affine> = vec![crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine()];
         // B = [ 0, c_2 ] (i.e. only e(X_2, c_2) term in equation)
-        let b_consts: Vec<G2Affine> = vec![ G2Affine::zero(), crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine()];
+        let b_consts: Vec<G2Affine> = vec![
+            G2Affine::zero(),
+            crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine(),
+        ];
         // Gamma = [ 5, 0 ] (i.e. only e(X_1, Y_1)^5 term)
-        let gamma: Matrix<Fr> = vec![vec![field_new!(Fr, "5")], vec![Fr::zero()]];
+        let gamma: Matrix<Fr> = vec![vec![Fr::from_str("5").unwrap()], vec![Fr::zero()]];
         // Target -> all together (n.b. e(X_1, Y_1)^5 = e(X_1, 5 Y_1) = e(5 X_1, Y_1) by the properties of non-degenerate bilinear maps)
-        let target: Fqk = F::pairing(xvars[1].clone(), b_consts[1].clone()) * F::pairing(a_consts[0].clone(), yvars[0].clone()) * F::pairing(xvars[0].clone(), yvars[0].mul(gamma[0][0].clone()).into_affine());
+        let target: Fqk = F::pairing(xvars[1].clone(), b_consts[1].clone()).0
+            * F::pairing(a_consts[0].clone(), yvars[0].clone()).0
+            * F::pairing(
+                xvars[0].clone(),
+                yvars[0].mul(gamma[0][0].clone()).into_affine(),
+            )
+            .0;
         let equ: PPE<F> = PPE::<F> {
-            a_consts, b_consts, gamma, target
+            a_consts,
+            b_consts,
+            gamma,
+            target,
         };
 
         let proof: CProof<F> = equ.commit_and_prove(&xvars, &yvars, &crs, &mut rng);
@@ -58,7 +68,6 @@ mod SXDH_prover_tests {
 
     #[test]
     fn multi_scalar_mult_equation_G1_verifies() {
-
         let mut rng = test_rng();
         let crs = CRS::<F>::generate_crs(&mut rng);
 
@@ -67,24 +76,28 @@ mod SXDH_prover_tests {
 
         // X = [ X_1, X_2 ] = [2 g1, 3 g1]
         let xvars: Vec<G1Affine> = vec![
-            crs.g1_gen.mul(field_new!(Fr, "2")).into_affine(),
-            crs.g1_gen.mul(field_new!(Fr, "3")).into_affine()
+            crs.g1_gen.mul(Fr::from_str("2").unwrap()).into_affine(),
+            crs.g1_gen.mul(Fr::from_str("3").unwrap()).into_affine(),
         ];
         // y = [ y_1 ] = [ 4 ]
-        let scalar_yvars: Vec<Fr> = vec![
-            field_new!(Fr, "4")
-        ];
+        let scalar_yvars: Vec<Fr> = vec![Fr::from_str("4").unwrap()];
 
         // A = [ c_1 ] (i.e. y_1 * c_1 term in equation)
-        let a_consts: Vec<G1Affine> = vec![ crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine() ];
+        let a_consts: Vec<G1Affine> = vec![crs.g1_gen.mul(Fr::rand(&mut rng)).into_affine()];
         // B = [ 0, c_2 ] (i.e. only c_2 * X_2 term in equation)
-        let b_consts: Vec<Fr> = vec![ Fr::zero(), Fr::rand(&mut rng) ];
+        let b_consts: Vec<Fr> = vec![Fr::zero(), Fr::rand(&mut rng)];
         // Gamma = [ 5, 0 ] (i.e. only (y_1 * X_1)*5 term)
-        let gamma: Matrix<Fr> = vec![vec![field_new!(Fr, "5")], vec![Fr::zero()]];
+        let gamma: Matrix<Fr> = vec![vec![Fr::from_str("5").unwrap()], vec![Fr::zero()]];
         // Target -> all together
-        let target: G1Affine = (xvars[1].mul(b_consts[1]) + a_consts[0].mul(scalar_yvars[0]) + xvars[0].mul(scalar_yvars[0] * gamma[0][0])).into_affine();
+        let target: G1Affine = (xvars[1].mul(b_consts[1])
+            + a_consts[0].mul(scalar_yvars[0])
+            + xvars[0].mul(scalar_yvars[0] * gamma[0][0]))
+        .into_affine();
         let equ: MSMEG1<F> = MSMEG1::<F> {
-            a_consts, b_consts, gamma, target
+            a_consts,
+            b_consts,
+            gamma,
+            target,
         };
 
         let proof: CProof<F> = equ.commit_and_prove(&xvars, &scalar_yvars, &crs, &mut rng);
@@ -93,7 +106,6 @@ mod SXDH_prover_tests {
 
     #[test]
     fn multi_scalar_mult_equation_G2_verifies() {
-
         let mut rng = test_rng();
         let crs = CRS::<F>::generate_crs(&mut rng);
 
@@ -101,25 +113,29 @@ mod SXDH_prover_tests {
         // by variables x_1, x_2 in Fr and Y_1 in G2, and constants c_1 in Fr and c_2 in G2
 
         // x = [ x_1, x_2 ] = [2, 3]
-        let scalar_xvars: Vec<Fr> = vec![
-            field_new!(Fr, "2"),
-            field_new!(Fr, "3")
-        ];
+        let scalar_xvars: Vec<Fr> = vec![Fr::from_str("2").unwrap(), Fr::from_str("3").unwrap()];
         // Y = [ y_1 ] = [ 4 g2 ]
-        let yvars: Vec<G2Affine> = vec![
-            crs.g2_gen.mul(field_new!(Fr, "4")).into_affine()
-        ];
+        let yvars: Vec<G2Affine> = vec![crs.g2_gen.mul(Fr::from_str("4").unwrap()).into_affine()];
 
         // A = [ c_1 ] (i.e. c_1 * Y_1 term in equation)
-        let a_consts: Vec<Fr> = vec![ Fr::rand(&mut rng) ];
+        let a_consts: Vec<Fr> = vec![Fr::rand(&mut rng)];
         // B = [ 0, c_2 ] (i.e. only x_2 * c_2 term in equation)
-        let b_consts: Vec<G2Affine> = vec![ G2Affine::zero(), crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine() ];
+        let b_consts: Vec<G2Affine> = vec![
+            G2Affine::zero(),
+            crs.g2_gen.mul(Fr::rand(&mut rng)).into_affine(),
+        ];
         // Gamma = [ 5, 0 ] (i.e. only (x_1 * Y_1)*5 term)
-        let gamma: Matrix<Fr> = vec![vec![field_new!(Fr, "5")], vec![Fr::zero()]];
+        let gamma: Matrix<Fr> = vec![vec![Fr::from_str("5").unwrap()], vec![Fr::zero()]];
         // Target -> all together
-        let target: G2Affine = (b_consts[1].mul(scalar_xvars[1]) + yvars[0].mul(a_consts[0]) + yvars[0].mul(scalar_xvars[0] * gamma[0][0])).into_affine();
+        let target: G2Affine = (b_consts[1].mul(scalar_xvars[1])
+            + yvars[0].mul(a_consts[0])
+            + yvars[0].mul(scalar_xvars[0] * gamma[0][0]))
+        .into_affine();
         let equ: MSMEG2<F> = MSMEG2::<F> {
-            a_consts, b_consts, gamma, target
+            a_consts,
+            b_consts,
+            gamma,
+            target,
         };
 
         let proof: CProof<F> = equ.commit_and_prove(&scalar_xvars, &yvars, &crs, &mut rng);
@@ -128,7 +144,6 @@ mod SXDH_prover_tests {
 
     #[test]
     fn quadratic_equation_verifies() {
-
         let mut rng = test_rng();
         let crs = CRS::<F>::generate_crs(&mut rng);
 
@@ -136,25 +151,25 @@ mod SXDH_prover_tests {
         // by variables x_1, x_2 and y_1 in Fr, and constants c_1 and c_2 in Fr
 
         // x = [ x_1, x_2 ] = [2, 3]
-        let scalar_xvars: Vec<Fr> = vec![
-            field_new!(Fr, "2"),
-            field_new!(Fr, "3")
-        ];
+        let scalar_xvars: Vec<Fr> = vec![Fr::from_str("2").unwrap(), Fr::from_str("3").unwrap()];
         // y = [ y_1 ] = [ 4 ]
-        let scalar_yvars: Vec<Fr> = vec![
-            field_new!(Fr, "4")
-        ];
+        let scalar_yvars: Vec<Fr> = vec![Fr::from_str("4").unwrap()];
 
         // A = [ c_1 ] (i.e. c_1 * y_1 term in equation)
-        let a_consts: Vec<Fr> = vec![ Fr::rand(&mut rng) ];
+        let a_consts: Vec<Fr> = vec![Fr::rand(&mut rng)];
         // B = [ 0, c_2 ] (i.e. only c_2 * x2 term in equation)
-        let b_consts: Vec<Fr> = vec![ Fr::zero(), Fr::rand(&mut rng) ];
+        let b_consts: Vec<Fr> = vec![Fr::zero(), Fr::rand(&mut rng)];
         // Gamma = [ 5, 0 ] (i.e. only (x_1 * y_1)*5 term)
-        let gamma: Matrix<Fr> = vec![vec![field_new!(Fr, "5")], vec![Fr::zero()]];
+        let gamma: Matrix<Fr> = vec![vec![Fr::from_str("5").unwrap()], vec![Fr::zero()]];
         // Target -> all together
-        let target: Fr = b_consts[1] * scalar_xvars[1] + scalar_yvars[0] * a_consts[0] + scalar_yvars[0] * scalar_xvars[0] * gamma[0][0];
+        let target: Fr = b_consts[1] * scalar_xvars[1]
+            + scalar_yvars[0] * a_consts[0]
+            + scalar_yvars[0] * scalar_xvars[0] * gamma[0][0];
         let equ: QuadEqu<F> = QuadEqu::<F> {
-            a_consts, b_consts, gamma, target
+            a_consts,
+            b_consts,
+            gamma,
+            target,
         };
 
         let proof: CProof<F> = equ.commit_and_prove(&scalar_xvars, &scalar_yvars, &crs, &mut rng);

--- a/tests/prover.rs
+++ b/tests/prover.rs
@@ -1,5 +1,4 @@
 #![allow(non_snake_case)]
-extern crate groth_sahai;
 
 #[cfg(test)]
 mod SXDH_prover_tests {


### PR DESCRIPTION
This PR updates the dependencies from the ark ecosystem to the 0.4 versions. The first commit  `Update to ark_* 0.4` is the main change that implements this update. The other commits fixes some clippy warnings after changing to 0.4. 