### PR TITLE
Update to ark_* 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 
 [dependencies]
-ark-ec = { version = "^0.4.0", default-features = false }
-ark-ff = { version = "^0.4.0", default-features = false }
-ark-std = { version = "^0.4.0", default-features = false }
+ark-ec = { version = "^0.5.0", default-features = false }
+ark-ff = { version = "^0.5.0", default-features = false }
+ark-std = { version = "^0.5.0", default-features = false }
 rayon = { version = "^1.5.1" }
 
 [dev-dependencies]
-ark-bls12-381 = { version = "^0.4.0" }
+ark-bls12-381 = { version = "^0.5.0" }
 criterion = { version = "0.3", features = [ "html_reports" ] } # benchmarks
 
 [profile.release]


### PR DESCRIPTION
`ark_*` 0.5 was released. No other changes are required.