### PR TITLE
Bump Rust edition to 2024.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "groth-sahai"
 version = "0.1.0"
 authors = ["Jacob White <white570@purdue.edu>"]
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "An implementation of the Groth-Sahai zero-knowledge proof system in Rust"
 repository = "https://github.com/jdwhite88/groth-sahai-rs"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,14 +1,14 @@
 #![allow(non_snake_case)]
 #![allow(dead_code)]
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use std::time::Duration;
 
 use ark_bls12_381::Bls12_381 as F;
 use ark_ec::{
-    pairing::{Pairing, PairingOutput},
     AffineRepr, CurveGroup,
+    pairing::{Pairing, PairingOutput},
 };
 use ark_ff::{One, UniformRand, Zero};
 use ark_std::ops::Mul;
@@ -16,13 +16,13 @@ use ark_std::str::FromStr;
 use ark_std::test_rng;
 
 use groth_sahai::{
+    AbstractCrs, B1, CRS, Com1, Mat, Matrix,
     prover::{
-        batch_commit_G1, batch_commit_G2, batch_commit_scalar_to_B1, batch_commit_scalar_to_B2,
-        CProof, Commit1, Commit2, Provable,
+        CProof, Commit1, Commit2, Provable, batch_commit_G1, batch_commit_G2,
+        batch_commit_scalar_to_B1, batch_commit_scalar_to_B2,
     },
     statement::PPE,
     verifier::Verifiable,
-    AbstractCrs, Com1, Mat, Matrix, B1, CRS,
 };
 
 type G1Projective = <F as Pairing>::G1;

--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -20,8 +20,8 @@
 //! well.
 
 use ark_ec::{
-    pairing::{Pairing, PairingOutput},
     AffineRepr, CurveGroup,
+    pairing::{Pairing, PairingOutput},
 };
 use ark_ff::{Field, One, Zero};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
@@ -905,8 +905,8 @@ mod tests {
 
         use ark_bls12_381::Bls12_381 as F;
         use ark_ec::{
-            pairing::{Pairing, PairingOutput},
             AffineRepr, CurveGroup,
+            pairing::{Pairing, PairingOutput},
         };
         use ark_ff::UniformRand;
         use ark_std::ops::Mul;

--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -125,15 +125,15 @@ pub trait BT<E: Pairing, C1: B1<E>, C2: B2<E>>: B<E> + From<Matrix<PairingOutput
 // SXDH instantiation's bilinear group for commitments
 
 /// Base [`B1`](crate::data_structures::B1) for the commitment group in the SXDH instantiation.
-#[derive(Copy, Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct Com1<E: Pairing>(pub E::G1Affine, pub E::G1Affine);
 
 /// Extension [`B2`](crate::data_structures::B2) for the commitment group in the SXDH instantiation.
-#[derive(Copy, Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct Com2<E: Pairing>(pub E::G2Affine, pub E::G2Affine);
 
 /// Target [`BT`](crate::data_structures::BT) for the commitment group in the SXDH instantiation.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct ComT<E: Pairing>(
     pub PairingOutput<E>,
     pub PairingOutput<E>,
@@ -167,16 +167,6 @@ macro_rules! impl_base_commit_groups {
     ) => {
         // Repeat for each $com
         $(
-            // Equality for Com group
-            impl<E: Pairing> PartialEq for $com<E> {
-
-                #[inline]
-                fn eq(&self, other: &Self) -> bool {
-                    self.0 == other.0 && self.1 == other.1
-                }
-            }
-            impl<E: Pairing> Eq for $com<E> {}
-
             // Addition for Com group
             impl<E: Pairing> Add<$com<E>> for $com<E> {
                 type Output = Self;
@@ -388,13 +378,6 @@ impl<E: Pairing> B2<E> for Com2<E> {
 }
 
 // ComT<Com1, Com2> is an instantiation of BT<B1, B2>
-impl<E: Pairing> PartialEq for ComT<E> {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0 && self.1 == other.1 && self.2 == other.2 && self.3 == other.3
-    }
-}
-impl<E: Pairing> Eq for ComT<E> {}
 
 impl<E: Pairing> Add<ComT<E>> for ComT<E> {
     type Output = Self;

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -14,8 +14,8 @@
 use crate::data_structures::{Com1, Com2};
 
 use ark_ec::{
-    pairing::{Pairing, PairingOutput},
     CurveGroup,
+    pairing::{Pairing, PairingOutput},
 };
 use ark_ff::{UniformRand, Zero};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
@@ -121,7 +121,7 @@ impl<E: Pairing> AbstractCrs<E> for CRS<E> {
 #[cfg(test)]
 mod tests {
     use ark_bls12_381::Bls12_381 as F;
-    use ark_ec::{pairing::Pairing, AffineRepr, CurveGroup};
+    use ark_ec::{AffineRepr, CurveGroup, pairing::Pairing};
     use ark_ff::Zero;
     use ark_std::test_rng;
 
@@ -151,7 +151,9 @@ mod tests {
     #[allow(non_snake_case)]
     #[test]
     fn test_valid_binding_CRS() {
-        std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
+        unsafe {
+            std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
+        }
         let mut rng = test_rng();
         let mut rng2 = test_rng();
 

--- a/src/prover/commit.rs
+++ b/src/prover/commit.rs
@@ -4,9 +4,9 @@
 
 use ark_ec::pairing::Pairing;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use ark_std::{fmt::Debug, rand::Rng, UniformRand};
+use ark_std::{UniformRand, fmt::Debug, rand::Rng};
 
-use crate::data_structures::{col_vec_to_vec, vec_to_col_vec, Com1, Com2, Mat, Matrix, B1, B2};
+use crate::data_structures::{B1, B2, Com1, Com2, Mat, Matrix, col_vec_to_vec, vec_to_col_vec};
 use crate::generator::CRS;
 
 pub trait Commit: Eq + Debug {
@@ -327,7 +327,9 @@ mod tests {
 
     #[test]
     fn test_commit_append_com1() {
-        std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
+        unsafe {
+            std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
+        }
         let mut rng = test_rng();
 
         let crs = CRS::<F>::generate_crs(&mut rng);
@@ -378,7 +380,9 @@ mod tests {
 
     #[test]
     fn test_commit_append_com2() {
-        std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
+        unsafe {
+            std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
+        }
         let mut rng = test_rng();
 
         let crs = CRS::<F>::generate_crs(&mut rng);
@@ -429,7 +433,9 @@ mod tests {
 
     #[test]
     fn test_commit_G1_batching() {
-        std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
+        unsafe {
+            std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
+        }
         let mut rng = test_rng();
         let mut rng2 = test_rng();
 
@@ -456,7 +462,9 @@ mod tests {
 
     #[test]
     fn test_commit_G2_batching() {
-        std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
+        unsafe {
+            std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
+        }
         let mut rng = test_rng();
         let mut rng2 = test_rng();
 
@@ -484,7 +492,9 @@ mod tests {
 
     #[test]
     fn test_commit_scalar_B1_batching() {
-        std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
+        unsafe {
+            std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
+        }
         let mut rng = test_rng();
         let mut rng2 = test_rng();
 
@@ -512,7 +522,9 @@ mod tests {
 
     #[test]
     fn test_commit_scalar_B2_batching() {
-        std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
+        unsafe {
+            std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
+        }
         let mut rng = test_rng();
         let mut rng2 = test_rng();
 

--- a/src/prover/commit.rs
+++ b/src/prover/commit.rs
@@ -15,13 +15,13 @@ pub trait Commit: Eq + Debug {
 }
 
 /// Contains both the commitment's values (as [`Com1`](crate::data_structures::Com1)) and its randomness.
-#[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct Commit1<E: Pairing> {
     pub coms: Vec<Com1<E>>,
     pub(super) rand: Matrix<E::ScalarField>,
 }
 /// Contains both the commitment's values (as [`Com2`](crate::data_structures::Com2)) and its randomness.
-#[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct Commit2<E: Pairing> {
     pub coms: Vec<Com2<E>>,
     pub(super) rand: Matrix<E::ScalarField>,
@@ -30,15 +30,6 @@ pub struct Commit2<E: Pairing> {
 macro_rules! impl_com {
     ($( $commit:ident ),*) => {
         $(
-            impl<E: Pairing> PartialEq for $commit<E> {
-
-                #[inline]
-                fn eq(&self, other: &Self) -> bool {
-                    self.coms == other.coms && self.rand == other.rand
-                }
-            }
-            impl<E: Pairing> Eq for $commit<E> {}
-
             impl<E: Pairing> Commit for $commit<E> {
                 fn append(&mut self, other: &mut Self) {
                     // One row of random values per committed value

--- a/src/prover/prove.rs
+++ b/src/prover/prove.rs
@@ -15,15 +15,15 @@
 use ark_ec::pairing::Pairing;
 use ark_ec::pairing::PairingOutput;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use ark_std::{rand::Rng, UniformRand};
+use ark_std::{UniformRand, rand::Rng};
 
 use super::commit::{
-    batch_commit_G1, batch_commit_G2, batch_commit_scalar_to_B1, batch_commit_scalar_to_B2,
-    Commit1, Commit2,
+    Commit1, Commit2, batch_commit_G1, batch_commit_G2, batch_commit_scalar_to_B1,
+    batch_commit_scalar_to_B2,
 };
-use crate::data_structures::{col_vec_to_vec, vec_to_col_vec, Com1, Com2, Mat, Matrix, B1, B2};
+use crate::data_structures::{B1, B2, Com1, Com2, Mat, Matrix, col_vec_to_vec, vec_to_col_vec};
 use crate::generator::CRS;
-use crate::statement::{EquType, QuadEqu, MSMEG1, MSMEG2, PPE};
+use crate::statement::{EquType, MSMEG1, MSMEG2, PPE, QuadEqu};
 
 /// A collection  of attributes containing prover functionality for an [`Equation`](crate::statement::Equation).
 pub trait Provable<E: Pairing, A1, A2, AT> {
@@ -536,7 +536,9 @@ mod tests {
 
     #[test]
     fn test_PPE_cproof_is_commit_and_prove() {
-        std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
+        unsafe {
+            std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
+        }
         let mut rng = test_rng();
         let mut rng2 = test_rng();
         let crs = CRS::<F>::generate_crs(&mut rng);
@@ -651,7 +653,9 @@ mod tests {
 
     #[test]
     fn test_MSMEG1_cproof_is_commit_and_prove() {
-        std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
+        unsafe {
+            std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
+        }
         let mut rng = test_rng();
         let mut rng2 = test_rng();
         let crs = CRS::<F>::generate_crs(&mut rng);

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -8,11 +8,11 @@
 use ark_ec::pairing::Pairing;
 
 use crate::data_structures::{
-    col_vec_to_vec, vec_to_col_vec, Com1, Com2, ComT, Mat, Matrix, B1, B2, BT,
+    B1, B2, BT, Com1, Com2, ComT, Mat, Matrix, col_vec_to_vec, vec_to_col_vec,
 };
 use crate::generator::CRS;
 use crate::prover::CProof;
-use crate::statement::{Equation, QuadEqu, MSMEG1, MSMEG2, PPE};
+use crate::statement::{Equation, MSMEG1, MSMEG2, PPE, QuadEqu};
 
 /// A collection of attributes containing verifier functionality for an [`Equation`](crate::statement::Equation).
 pub trait Verifiable<E: Pairing> {

--- a/tests/commit.rs
+++ b/tests/commit.rs
@@ -4,8 +4,8 @@
 mod SXDH_commit_tests {
 
     use ark_bls12_381::Bls12_381 as F;
-    use ark_ec::pairing::Pairing;
     use ark_ec::CurveGroup;
+    use ark_ec::pairing::Pairing;
     use ark_ff::UniformRand;
     use ark_std::ops::Mul;
     use ark_std::test_rng;

--- a/tests/prover.rs
+++ b/tests/prover.rs
@@ -8,7 +8,7 @@ mod SXDH_prover_tests {
     use ark_ec::{AffineRepr, CurveGroup};
     use ark_std::ops::Mul;
     use ark_std::str::FromStr;
-    use ark_std::{test_rng, UniformRand, Zero};
+    use ark_std::{UniformRand, Zero, test_rng};
 
     use groth_sahai::data_structures::*;
     use groth_sahai::prover::*;


### PR DESCRIPTION
Note that calls to `std::env::set_var` are now unsafe.